### PR TITLE
fix: reset collector gauges before emitting fresh pod labels

### DIFF
--- a/internal/collector/health.go
+++ b/internal/collector/health.go
@@ -46,6 +46,9 @@ func (d *DeviceHealthCollector) GetMetrics(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	d.healthStatus.Reset()
+
 	for _, s := range deviceStatus {
 		labels := prometheus.Labels{
 			"card":             s.Card,

--- a/internal/collector/hwinfo.go
+++ b/internal/collector/hwinfo.go
@@ -54,6 +54,10 @@ func (h *HardwareInfoCollector) GetMetrics(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	h.temperature.Reset()
+	h.power.Reset()
+
 	for _, s := range deviceStatus {
 		labels := prometheus.Labels{
 			"card":             s.Card,

--- a/internal/collector/memory.go
+++ b/internal/collector/memory.go
@@ -55,6 +55,9 @@ func (m *MemoryCollector) GetMetrics(ctx context.Context) error {
 		return err
 	}
 
+	m.dramUsed.Reset()
+	m.dramTotal.Reset()
+
 	for _, s := range deviceStatus {
 		labels := prometheus.Labels{
 			"card":             s.Card,

--- a/internal/collector/utilization.go
+++ b/internal/collector/utilization.go
@@ -47,6 +47,8 @@ func (u *UtilizationCollector) GetMetrics(ctx context.Context) error {
 		return err
 	}
 
+	u.utilization.Reset()
+
 	for _, s := range deviceStatus {
 		labels := prometheus.Labels{
 			"card":             s.Card,


### PR DESCRIPTION
### Motivation
Stale label combinations from previous pod assignments stayed registered in Prometheus, so a single device could expose multiple outdated pod/container pairs. Resetting the gauges in each scrape ensures we only publish the containers currently bound to a device.

## Summary of Changes
- Reset the `health`, `hwinfo`, `memory`, and `utilization` `GaugeVec`s prior to repopulating them with fresh label sets.
- Limit the exported metrics to the pod/container combinations actually observed in the current scrape cycle, removing stale time series automatically.

## Technical Details
- This approach relies on the natural behavior of `GaugeVec.Reset()` to drop previously registered label combinations, so no manual delete bookkeeping is needed.