### PR TITLE
feat: cache pod resources and share mapper across collectors

### DIFF
--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -50,10 +50,11 @@ func Start(ctx context.Context, config Config) error {
 	}
 
 	metricRegistry := prometheus.NewRegistry()
-	collectorFactory := collector.NewCollectorFactory(metricRegistry, dClient, config.NodeName)
+	podResourceMapper := collector.NewPodResourceMapper(ctx)
+	collectorFactory := collector.NewCollectorFactory(podResourceMapper, metricRegistry, dClient, config.NodeName)
 	collectors := collectorFactory.NewCollectors()
 
-	sched := scheduler.NewScheduler(collectors, config.Interval)
+	sched := scheduler.NewScheduler(podResourceMapper, collectors, config.Interval)
 	go sched.Run(ctx)
 
 	server := server.NewMetricServer(metricRegistry, config.Port)

--- a/internal/collector/collector_factory.go
+++ b/internal/collector/collector_factory.go
@@ -13,8 +13,7 @@ type collectorFactory struct {
 	nodeName          string
 }
 
-func NewCollectorFactory(registry prometheus.Registerer, dClient *daemon.Client, nodeName string) *collectorFactory {
-	podResourceMapper := NewPodResourceMapper()
+func NewCollectorFactory(podResourceMapper *PodResourceMapper, registry prometheus.Registerer, dClient *daemon.Client, nodeName string) *collectorFactory {
 	return &collectorFactory{
 		registry:          registry,
 		dClient:           dClient,

--- a/internal/collector/health.go
+++ b/internal/collector/health.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rebellions-sw/rbln-metrics-exporter/internal/daemon"
@@ -36,11 +35,7 @@ func (d *DeviceHealthCollector) Register(registerer prometheus.Registerer) {
 }
 
 func (d *DeviceHealthCollector) GetMetrics(ctx context.Context) error {
-	podResourceInfo, err := d.podResourceMapper.GetResourcesInfo()
-	if err != nil {
-		slog.Error("Failed to get resources info", "error", err)
-		return err
-	}
+	podResourceInfo := d.podResourceMapper.Snapshot()
 
 	deviceStatus, err := d.dClient.GetDeviceStatus(ctx)
 	if err != nil {
@@ -59,9 +54,9 @@ func (d *DeviceHealthCollector) GetMetrics(ctx context.Context) error {
 			"driver_version":   s.DriverVersion,
 			"firmware_version": s.FirmwareVersion,
 			"smc_version":      s.SMCVersion,
-			"namespace":        podResourceInfo[s.Name].Namespace,
-			"pod":              podResourceInfo[s.Name].Name,
-			"container":        podResourceInfo[s.Name].ContainerName,
+			"namespace":        podResourceInfo[DeviceName(s.Name)].Namespace,
+			"pod":              podResourceInfo[DeviceName(s.Name)].Name,
+			"container":        podResourceInfo[DeviceName(s.Name)].ContainerName,
 		}
 		d.healthStatus.With(labels).Set(float64(s.DeviceStatus))
 	}

--- a/internal/collector/hwinfo.go
+++ b/internal/collector/hwinfo.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rebellions-sw/rbln-metrics-exporter/internal/daemon"
@@ -44,11 +43,7 @@ func (h *HardwareInfoCollector) Register(registerer prometheus.Registerer) {
 }
 
 func (h *HardwareInfoCollector) GetMetrics(ctx context.Context) error {
-	podResourceInfo, err := h.podResourceMapper.GetResourcesInfo()
-	if err != nil {
-		slog.Error("Failed to get resources info", "error", err)
-		return err
-	}
+	podResourceInfo := h.podResourceMapper.Snapshot()
 
 	deviceStatus, err := h.dClient.GetDeviceStatus(ctx)
 	if err != nil {
@@ -68,9 +63,9 @@ func (h *HardwareInfoCollector) GetMetrics(ctx context.Context) error {
 			"driver_version":   s.DriverVersion,
 			"firmware_version": s.FirmwareVersion,
 			"smc_version":      s.SMCVersion,
-			"namespace":        podResourceInfo[s.Name].Namespace,
-			"pod":              podResourceInfo[s.Name].Name,
-			"container":        podResourceInfo[s.Name].ContainerName,
+			"namespace":        podResourceInfo[DeviceName(s.Name)].Namespace,
+			"pod":              podResourceInfo[DeviceName(s.Name)].Name,
+			"container":        podResourceInfo[DeviceName(s.Name)].ContainerName,
 		}
 		h.temperature.With(labels).Set(s.Temperature)
 		h.power.With(labels).Set(s.Power)

--- a/internal/collector/memory.go
+++ b/internal/collector/memory.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rebellions-sw/rbln-metrics-exporter/internal/daemon"
@@ -44,11 +43,7 @@ func (m *MemoryCollector) Register(reg prometheus.Registerer) {
 }
 
 func (m *MemoryCollector) GetMetrics(ctx context.Context) error {
-	podResourceInfo, err := m.podResourceMapper.GetResourcesInfo()
-	if err != nil {
-		slog.Error("Failed to get resources info", "error", err)
-		return err
-	}
+	podResourceInfo := m.podResourceMapper.Snapshot()
 
 	deviceStatus, err := m.dClient.GetDeviceStatus(ctx)
 	if err != nil {
@@ -68,9 +63,9 @@ func (m *MemoryCollector) GetMetrics(ctx context.Context) error {
 			"driver_version":   s.DriverVersion,
 			"firmware_version": s.FirmwareVersion,
 			"smc_version":      s.SMCVersion,
-			"namespace":        podResourceInfo[s.Name].Namespace,
-			"pod":              podResourceInfo[s.Name].Name,
-			"container":        podResourceInfo[s.Name].ContainerName,
+			"namespace":        podResourceInfo[DeviceName(s.Name)].Namespace,
+			"pod":              podResourceInfo[DeviceName(s.Name)].Name,
+			"container":        podResourceInfo[DeviceName(s.Name)].ContainerName,
 		}
 		m.dramUsed.With(labels).Set(s.DRAMUsedGiB)
 		m.dramTotal.With(labels).Set(s.DRAMTotalGiB)

--- a/internal/collector/utilization.go
+++ b/internal/collector/utilization.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rebellions-sw/rbln-metrics-exporter/internal/daemon"
@@ -36,11 +35,7 @@ func (u *UtilizationCollector) Register(reg prometheus.Registerer) {
 }
 
 func (u *UtilizationCollector) GetMetrics(ctx context.Context) error {
-	podResourceInfo, err := u.podResourceMapper.GetResourcesInfo()
-	if err != nil {
-		slog.Error("Failed to get resources info", "error", err)
-		return err
-	}
+	podResourceInfo := u.podResourceMapper.Snapshot()
 
 	deviceStatus, err := u.dClient.GetDeviceStatus(ctx)
 	if err != nil {
@@ -59,9 +54,9 @@ func (u *UtilizationCollector) GetMetrics(ctx context.Context) error {
 			"driver_version":   s.DriverVersion,
 			"firmware_version": s.FirmwareVersion,
 			"smc_version":      s.SMCVersion,
-			"namespace":        podResourceInfo[s.Name].Namespace,
-			"pod":              podResourceInfo[s.Name].Name,
-			"container":        podResourceInfo[s.Name].ContainerName,
+			"namespace":        podResourceInfo[DeviceName(s.Name)].Namespace,
+			"pod":              podResourceInfo[DeviceName(s.Name)].Name,
+			"container":        podResourceInfo[DeviceName(s.Name)].ContainerName,
 		}
 		u.utilization.With(labels).Set(s.Utilization)
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -9,18 +9,21 @@ import (
 )
 
 type Scheduler struct {
-	collectors []collector.Collector
-	interval   time.Duration
+	collectors        []collector.Collector
+	interval          time.Duration
+	podResourceMapper *collector.PodResourceMapper
 }
 
-func NewScheduler(collectors []collector.Collector, interval time.Duration) *Scheduler {
+func NewScheduler(podResourceMapper *collector.PodResourceMapper, collectors []collector.Collector, interval time.Duration) *Scheduler {
 	return &Scheduler{
-		collectors: collectors,
-		interval:   interval,
+		collectors:        collectors,
+		interval:          interval,
+		podResourceMapper: podResourceMapper,
 	}
 }
 
 func (s *Scheduler) RunOnce(ctx context.Context) error {
+	s.podResourceMapper.TriggerSync()
 	for _, collector := range s.collectors {
 		if err := collector.GetMetrics(ctx); err != nil {
 			return err


### PR DESCRIPTION
## Motivation
Repeatedly calling kubelet’s pod-resources API for every device scrape overloaded kubelet. We need to collect pod metadata once per interval and reuse it.

## Summary of Changes
- add a `PodResourceMapper` that syncs pod resources asynchronously, caches them, and exposes `TriggerSync`/`Snapshot`
- wire the mapper through `Start`, the collector factory, and the scheduler; trigger a sync each tick and let all collectors read from the cached snapshot

## Technical Details
- `PodResourceMapper` holds a guarded `podResourcesByDevice` map, runs a goroutine to process sync requests, and uses `maps.Copy` to provide thread-safe snapshots
- collectors now call `Snapshot()` (no kubelet calls), and the scheduler initiates syncs on every interval so kubelet is contacted at most once per tick