### PR TITLE
refactor: use kubelet device ID directly as device name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 bin/*
 
 .go-version
+
+CLAUDE.md
+.claude

--- a/deployments/kubernetes/daemonset-kubernetes-off.yaml
+++ b/deployments/kubernetes/daemonset-kubernetes-off.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: rbln-system
   labels:
     app.kubernetes.io/name: rbln-metrics-exporter
+    app.kubernetes.io/component: metrics-exporter
     app.kubernetes.io/version: latest
 spec:
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rbln-metrics-exporter
+        app.kubernetes.io/component: metrics-exporter
         app.kubernetes.io/version: latest
     spec:
       affinity:
@@ -96,6 +98,7 @@ metadata:
   namespace: rbln-system
   labels:
     app.kubernetes.io/name: rbln-metrics-exporter
+    app.kubernetes.io/component: metrics-exporter
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: "/metrics"

--- a/deployments/kubernetes/daemonset.yaml
+++ b/deployments/kubernetes/daemonset.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: rbln-system
   labels:
     app.kubernetes.io/name: rbln-metrics-exporter
+    app.kubernetes.io/component: metrics-exporter
     app.kubernetes.io/version: latest
 spec:
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rbln-metrics-exporter
+        app.kubernetes.io/component: metrics-exporter
         app.kubernetes.io/version: latest
     spec:
       affinity:
@@ -94,6 +96,7 @@ metadata:
   namespace: rbln-system
   labels:
     app.kubernetes.io/name: rbln-metrics-exporter
+    app.kubernetes.io/component: metrics-exporter
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: "/metrics"

--- a/internal/collector/kubernetes.go
+++ b/internal/collector/kubernetes.go
@@ -18,7 +18,6 @@ import (
 const (
 	PodResourceSocket  = "/var/lib/kubelet/pod-resources/kubelet.sock"
 	RBLNResourcePrefix = "rebellions.ai"
-	SysfsDriverPools   = "/sys/bus/pci/drivers/rebellions/%s/pools"
 )
 
 type DeviceName string
@@ -107,11 +106,7 @@ func (p *PodResourceMapper) syncPodResources() error {
 			for _, containerDevice := range container.GetDevices() {
 				if strings.HasPrefix(containerDevice.GetResourceName(), RBLNResourcePrefix) {
 					for _, deviceID := range containerDevice.GetDeviceIds() {
-						deviceName, err := getDeviceName(deviceID)
-						if err != nil {
-							return err
-						}
-						podResourcesInfo[DeviceName(deviceName)] = PodResourceInfo{
+						podResourcesInfo[DeviceName(deviceID)] = PodResourceInfo{
 							Name:          pod.Name,
 							Namespace:     pod.Namespace,
 							ContainerName: container.Name,
@@ -153,18 +148,6 @@ func newKubeletClient() (*grpc.ClientConn, func(), error) {
 	return conn, func() {
 		_ = conn.Close()
 	}, nil
-}
-
-func getDeviceName(pciAddress string) (string, error) {
-	poolsFilePath := fmt.Sprintf(SysfsDriverPools, pciAddress)
-	poolsFile, err := os.ReadFile(poolsFilePath)
-	if err != nil {
-		slog.Error("Failed to read", "file", poolsFilePath, "err", err)
-		return "", fmt.Errorf("failed to read %s, %w", poolsFilePath, err)
-	}
-
-	deviceName := strings.Split(strings.Split(string(poolsFile), "\n")[1], " ")[0]
-	return deviceName, nil
 }
 
 func IsKubernetes() bool {


### PR DESCRIPTION
  ## Motivation
  The pod-resource mapper used to translate kubelet `deviceId` (PCI address) to a
  device name by reading `/sys/bus/pci/drivers/rebellions/<addr>/pools`. Since the
  daemon now reports devices by the same ID kubelet hands out, the sysfs lookup is
  redundant and adds an unnecessary host-path dependency.

  ## Summary of Changes
  - Drop sysfs-based PCI-to-device-name resolution in `internal/collector/kubernetes.go`; use the kubelet
  `deviceId` directly as `DeviceName`.
  - Add `app.kubernetes.io/component: metrics-exporter` label to DaemonSet, Pod template, and Service in both
  `daemonset.yaml` and `daemonset-kubernetes-off.yaml`.