### PR TITLE
ci(release): build multi-arch images via dedicated arm64 runner and manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,34 +9,79 @@ permissions:
   contents: write
 
 jobs:
-  build-and-push-image:
-    name: Build and push image
+  build-amd64:
+    name: Build and push amd64 image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and push RBLN metrics exporter image
+      - name: Build and push amd64 image
         env:
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ github.ref_name }}-amd64
           REGISTRY: docker.io/rebellions
           PUSH_ON_BUILD: "true"
-          BUILD_MULTI_PLATFORM: "false" # TODO(mskim): revert when dedicated ARM runners become available
+          PLATFORM: linux/amd64
         run: make build-image
+
+  build-arm64:
+    name: Build and push arm64 image
+    runs-on: ubuntu-22.04-rbln-arm
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push arm64 image
+        env:
+          VERSION: ${{ github.ref_name }}-arm64
+          REGISTRY: docker.io/rebellions
+          PUSH_ON_BUILD: "true"
+          PLATFORM: linux/arm64
+        run: make build-image
+
+  manifest:
+    name: Create multi-arch manifest
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: docker.io/rebellions/rbln-metrics-exporter
+    steps:
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Create version and latest manifests
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${{ github.ref_name }}" \
+            "${IMAGE}:${{ github.ref_name }}-amd64" \
+            "${IMAGE}:${{ github.ref_name }}-arm64"
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${{ github.ref_name }}-amd64" \
+            "${IMAGE}:${{ github.ref_name }}-arm64"
 
   draft-release:
     needs:
-      - build-and-push-image
+      - manifest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -17,25 +17,47 @@ jobs:
   build-and-push-image:
     needs: [code-check, go-build]
     name: Build and push RBLN metrics exporter image
-    runs-on: ubuntu-latest
+    runs-on: rbln-sw-k8s-general
+    env:
+      IMAGE: harbor.k8s.rebellions.in/rebellions/rbln-metrics-exporter
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Install prerequisites
+        run: |
+          if ! command -v docker &>/dev/null; then
+            curl -fsSL https://get.docker.com | sudo sh
+            sudo usermod -aG docker "$USER"
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          if ! command -v make &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y make
+          fi
+
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to Harbor
         uses: docker/login-action@v3
         with:
-          registry: docker.io
+          registry: harbor.k8s.rebellions.in
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Login to Docker Hub for base-image pulls
+        uses: docker/login-action@v3
+        with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push image
         env:
-          VERSION: "latest"
-          REGISTRY: docker.io/rebellions
+          VERSION: ${{ github.sha }}
+          REGISTRY: harbor.k8s.rebellions.in/rebellions
           PUSH_ON_BUILD: "true"
           BUILD_MULTI_PLATFORM: "false" # TODO(mskim): revert when dedicated ARM runners become available
         run: make build-image
+
+      - name: Tag dev (alias of the immutable commit SHA)
+        run: docker buildx imagetools create --tag "${IMAGE}:dev" "${IMAGE}:${GITHUB_SHA}"

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,23 @@ DOCKER_BUILD_OPTIONS ?= --output=type=image,push=$(PUSH_ON_BUILD)
 BUILDX =
 USE_BUILDX = $(BUILD_MULTI_PLATFORM)
 
+# PLATFORM can be set to a single platform (e.g. linux/amd64, linux/arm64)
+# to override the default platform logic.
+PLATFORM ?=
+
 ifneq ($(PUSH_ON_BUILD),false)
+	USE_BUILDX = true
+endif
+
+ifneq ($(PLATFORM),)
 	USE_BUILDX = true
 endif
 
 ifeq ($(USE_BUILDX),true)
 	BUILDX = buildx
-ifeq ($(BUILD_MULTI_PLATFORM),true)
+ifneq ($(PLATFORM),)
+	DOCKER_BUILD_PLATFORM_OPTIONS := --platform=$(PLATFORM)
+else ifeq ($(BUILD_MULTI_PLATFORM),true)
 	DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64,linux/arm64
 else
 	DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64


### PR DESCRIPTION
  ## Motivation
  Dedicated ARM runners are now available, so we can build true multi-arch (amd64 + arm64)
  release images instead of the previous amd64-only workaround. CI dev builds are also moved
  off Docker Hub onto our internal Harbor registry running on a self-hosted runner.

  ## Summary of Changes
  - Split the release build into per-arch jobs (`build-amd64`, `build-arm64`) and add a
    `manifest` job that publishes a multi-arch manifest for `:<tag>` and `:latest`.
  - Switch the CI build (`trigger-ci.yaml`) to the self-hosted `rbln-sw-k8s-general` runner,
    push to Harbor, tag images by commit SHA, and add a `:dev` alias.
  - Add a `PLATFORM` override to the Makefile so a single target architecture can be built.