### PR TITLE
ci(release): install docker and make prerequisites on runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,16 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Install prerequisites
+        run: |
+          if ! command -v docker &>/dev/null; then
+            curl -fsSL https://get.docker.com | sudo sh
+            sudo usermod -aG docker "$USER"
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          if ! command -v make &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y make
+          fi
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub


### PR DESCRIPTION
##  Motivation

  The release workflow assumes docker and make are already available on the runner. On runners where they are not pre-installed, the job fails before it can build and push images.

##  Summary of Changes

  - Add an "Install prerequisites" step to the release workflow that installs docker and make when missing.