### PR TITLE
feat(metrics): export rbln_up in local mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Two failure signals exist and mean different things:
 | `rbln_npu_pcie_link_speed_gts` | Current PCIe link speed | GT/s |
 | `rbln_npu_pcie_link_width` | Current PCIe link width | lanes |
 | `rbln_npu_device_info` | Device identity and static attributes as labels | always 1 |
-| `rbln_up` | Gateway mode only: 1 if the target `rbln-smd` answered the scrape, 0 otherwise | 0/1 |
+| `rbln_up` | 1 if the last metrics collection from `rbln-smd` succeeded, 0 otherwise (local mode: the last scheduled collection cycle; gateway mode: the collection performed for this scrape) | 0/1 |
 
 ### Common Label Set
 
@@ -279,7 +279,7 @@ rbln_npu_health{card="RBLN-CA25",container="ubuntu",deviceID="1250",driver_versi
 
 | Symptom | Possible Cause | Action |
 | --- | --- | --- |
-| `/metrics` is empty | Unable to reach RBLN daemon | Verify `RBLN_METRICS_EXPORTER_RBLN_DAEMON_URL`, ensure daemon is listening, check firewall |
+| `rbln_up` is `0` and NPU metrics are absent | Unable to reach RBLN daemon | Verify `RBLN_METRICS_EXPORTER_RBLN_DAEMON_URL`, ensure daemon is listening, check firewall |
 | No Kubernetes labels | Pod-resources socket missing | Confirm `/var/lib/kubelet/pod-resources/kubelet.sock` is mounted and kubelet exposes the API |
 | Scrape errors in Prometheus | Authorization/namespace mismatch | Ensure Service or ServiceMonitor selects the exporter pods and Prometheus is allowed to scrape the namespace |
 | Gateway returns HTTP 400 | Missing `?target=` parameter | Check the `relabel_configs` copy rules run before `__address__` is replaced |

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -81,7 +81,10 @@ func Start(ctx context.Context, config Config) error {
 	)
 	collectors := collectorFactory.NewCollectors()
 
-	sched := scheduler.NewScheduler(podResourceMapper, collectors, config.Interval)
+	up := collector.NewUpGauge()
+	metricRegistry.MustRegister(up)
+
+	sched := scheduler.NewScheduler(podResourceMapper, collectors, config.Interval, up)
 	go sched.Run(ctx)
 
 	server := server.NewMetricServer(metricRegistry, config.Port)

--- a/internal/collector/types.go
+++ b/internal/collector/types.go
@@ -25,3 +25,10 @@ func metricName(legacy, current string) string {
 	}
 	return legacy
 }
+
+func NewUpGauge() prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "rbln_up",
+		Help: "1 if the last metrics collection from rbln-smd succeeded, 0 otherwise",
+	})
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -54,10 +54,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	registry := prometheus.NewRegistry()
-	up := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "rbln_up",
-		Help: "1 if the target rbln-smd answered the scrape, 0 otherwise",
-	})
+	up := collector.NewUpGauge()
 	registry.MustRegister(up)
 
 	collectorFactory := collector.NewCollectorFactory(

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rebellions-sw/rbln-metrics-exporter/internal/collector"
 )
 
@@ -12,13 +13,15 @@ type Scheduler struct {
 	collectors        []collector.Collector
 	interval          time.Duration
 	podResourceMapper *collector.PodResourceMapper
+	up                prometheus.Gauge
 }
 
-func NewScheduler(podResourceMapper *collector.PodResourceMapper, collectors []collector.Collector, interval time.Duration) *Scheduler {
+func NewScheduler(podResourceMapper *collector.PodResourceMapper, collectors []collector.Collector, interval time.Duration, up prometheus.Gauge) *Scheduler {
 	return &Scheduler{
 		collectors:        collectors,
 		interval:          interval,
 		podResourceMapper: podResourceMapper,
+		up:                up,
 	}
 }
 
@@ -26,9 +29,11 @@ func (s *Scheduler) RunOnce(ctx context.Context) error {
 	s.podResourceMapper.TriggerSync()
 	for _, collector := range s.collectors {
 		if err := collector.GetMetrics(ctx); err != nil {
+			s.up.Set(0)
 			return err
 		}
 	}
+	s.up.Set(1)
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

Prometheus `up` only covers the exporter process. In local mode a dead or hung `rbln-smd` still answers the scrape with HTTP 200 — the collectors reset on failure, so the outage surfaces as *absent* `rbln_*` series on an otherwise healthy target. Alerting on absence per node requires `absent()`-style rules that lose instance labels, which is impractical for a DaemonSet fleet. Gateway mode already exports `rbln_up` for exactly this reason; local mode should give the same signal so one alert rule covers both deployment shapes.

## Summary of Changes

- Export `rbln_up` in local mode: `1` when the last scheduled collection cycle succeeded, `0` when it failed (existing reset-on-error behavior is unchanged, so a failed cycle shows `rbln_up 0` with the NPU series absent).
- Extract the gauge definition into a shared `collector.NewUpGauge()` used by both local and gateway mode, so the metric name and help text cannot drift between modes.
- README: drop "Gateway mode only" from the metrics table (documenting the per-mode semantics), and update the troubleshooting entry — a daemon outage now shows as `rbln_up 0` rather than an empty `/metrics`.

## Technical Details

- `scheduler.RunOnce` sets the gauge after the collection loop: `0` on the first collector error, `1` when all collectors succeed. The gauge is registered on the local-mode registry in `cmd.Start` and injected into the scheduler.
- Semantics differ slightly by mode — gateway sets it per scrape, local mode per scheduled cycle — so the shared help text reads "1 if the last metrics collection from rbln-smd succeeded, 0 otherwise".
- A plain registered gauge exports `0` immediately, so `rbln_up 0` is visible between exporter start and the first collection cycle (default 5s); alert rules with a `for:` duration are unaffected.
- Verified against the live `rbln-daemon` in the rn-ci cluster (port-forwarded): healthy daemon → `rbln_up 1` + full metric set; port-forward killed → next cycle serves `rbln_up 0` with NPU series absent and HTTP still 200; daemon restored → back to `rbln_up 1`. Gateway mode regression-checked with the shared gauge (reachable target `1`, unreachable `0`).
