### PR TITLE
feat(logging): structured logging with env control and device visibility records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY . .
 
 ENV CGO_ENABLED=0
+ARG VERSION
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o /usr/local/bin/rbln-metrics-exporter ./cmd/rbln-metrics-exporter
+    go build -ldflags "-X github.com/rebellions-sw/rbln-metrics-exporter/internal/cmd.Version=${VERSION:-dev}" \
+    -o /usr/local/bin/rbln-metrics-exporter ./cmd/rbln-metrics-exporter
 
 FROM redhat/ubi9-minimal:9.6
 ARG VERSION
@@ -44,8 +46,6 @@ RUN chown rbln:rbln /usr/local/bin/rbln-metrics-exporter && \
     chmod 755 /usr/local/bin/rbln-metrics-exporter
 
 USER rbln
-
-ENV RBLN_METRICS_EXPORTER_LOG_LEVEL=info
 
 EXPOSE 9090
 

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,11 @@ IMAGE_NAME ?= $(REGISTRY)/rbln-metrics-exporter
 IMAGE_TAG ?= $(VERSION)
 IMAGE := $(IMAGE_NAME):$(IMAGE_TAG)
 
+GO_LDFLAGS := -X github.com/rebellions-sw/rbln-metrics-exporter/internal/cmd.Version=$(VERSION)
+
 .PHONY: build
 build:
-	CGO_ENABLED=0 $(GO) build -o bin/$(BINARY) $(CMD_DIR)
+	CGO_ENABLED=0 $(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(BINARY) $(CMD_DIR)
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Flags:
 | `RBLN_METRICS_EXPORTER_KUBERNETES_MODE` | `auto` | Kubernetes integration: `auto`, `on`, or `off` |
 | `RBLN_METRICS_EXPORTER_ONESHOT` | `false` | When `true`, scrape once and exit |
 | `NODE_NAME` | auto-detected | Overrides the node label inserted into metrics |
+| `LOG_LEVEL` | `info` | Log level: `error`, `warning`, `info`, `debug`, or `trace` |
+| `LOG_FORMAT` | `json` | Log output format: `json` or `text` |
+
+> `LOG_LEVEL=warning` is emitted in logs as `"level":"warn"` (slog's canonical spelling) — write dashboard/alert filters against `warn`, not `warning`.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Flags:
 
 > `LOG_LEVEL=warning` is emitted in logs as `"level":"warn"` (slog's canonical spelling) — write dashboard/alert filters against `warn`, not `warning`.
 
+> **For log pipelines:** records are single-line JSON (NDJSON) on **stdout**. The timestamp key is `ts` in RFC3339Nano with variable fractional digits — set Fluent Bit's JSON parser to `Time_Key ts`; promtail's `RFC3339Nano` format works as-is. The message key is `msg`, the error key is `err`, and `caller` (`pkg/file.go:N`) appears only at `debug`/`trace`. Keep `json` in-cluster; `text` is meant for local debugging.
+
 
 ---
 

--- a/cmd/rbln-metrics-exporter/main.go
+++ b/cmd/rbln-metrics-exporter/main.go
@@ -3,33 +3,16 @@ package main
 import (
 	"log/slog"
 	"os"
-	"time"
 
 	appcmd "github.com/rebellions-sw/rbln-metrics-exporter/internal/cmd"
+	"github.com/rebellions-sw/rbln-metrics-exporter/internal/logging"
 )
 
-func initLogger() {
-	opts := &slog.HandlerOptions{
-		Level:     slog.LevelDebug,
-		AddSource: true,
-		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-			if a.Key == slog.TimeKey {
-				a.Value = slog.StringValue(a.Value.Time().Format(time.RFC3339))
-			}
-			return a
-		},
-	}
-
-	handler := slog.NewJSONHandler(os.Stdout, opts)
-	logger := slog.New(handler)
-	slog.SetDefault(logger)
-}
-
 func main() {
-	initLogger()
+	logging.SetupFromEnv()
 	app := appcmd.NewApp()
 	if err := app.Execute(); err != nil {
-		slog.Error("command execution failed", "err", err)
+		slog.Error("Command execution failed", "err", err)
 		os.Exit(1)
 	}
 }

--- a/deployments/kubernetes/daemonset.yaml
+++ b/deployments/kubernetes/daemonset.yaml
@@ -46,6 +46,11 @@ spec:
                   fieldPath: spec.nodeName
             - name: RBLN_METRICS_EXPORTER_RBLN_DAEMON_URL
               value: "$(NODE_IP):50051"
+            # Uncomment to override the logging defaults (info level, json format)
+            # - name: LOG_LEVEL
+            #   value: "debug"
+            # - name: LOG_FORMAT
+            #   value: "json"
           volumeMounts:
             - name: pod-resources
               mountPath: /var/lib/kubelet/pod-resources

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -64,6 +64,7 @@ func Start(ctx context.Context, config Config) error {
 
 	metricRegistry := prometheus.NewRegistry()
 	isKubernetes := resolveKubernetesMode(config.KubernetesMode)
+	slog.Debug("Resolved Kubernetes mode", "mode", config.KubernetesMode, "kubernetes", isKubernetes)
 	var podResourceMapper *collector.PodResourceMapper
 	if isKubernetes {
 		podResourceMapper, err = collector.NewPodResourceMapper(ctx)

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -42,7 +43,7 @@ func Start(ctx context.Context, config Config) error {
 	slog.Info("Starting rbln-metrics-exporter", "config", config)
 	if os.Getenv("PROMETHEUS_METRIC_NAMES") != "true" {
 		slog.Warn(
-			"legacy metric names are deprecated and will be removed in the next version; set PROMETHEUS_METRIC_NAMES=true to enable the new metric names",
+			"Legacy metric names are deprecated and will be removed in the next version; set PROMETHEUS_METRIC_NAMES=true to enable the new metric names",
 			"env", "PROMETHEUS_METRIC_NAMES",
 		)
 	}
@@ -89,8 +90,7 @@ func Start(ctx context.Context, config Config) error {
 
 	server := server.NewMetricServer(metricRegistry, config.Port)
 	if err := server.Start(ctx); err != nil {
-		slog.Error("http metrics server stopped", "err", err)
-		return err
+		return fmt.Errorf("http metrics server stopped: %w", err)
 	}
 
 	return nil
@@ -105,8 +105,7 @@ func startGateway(ctx context.Context, config Config) error {
 
 	srv := server.NewServer(mux, config.Port)
 	if err := srv.Start(ctx); err != nil {
-		slog.Error("http metrics server stopped", "err", err)
-		return err
+		return fmt.Errorf("http metrics server stopped: %w", err)
 	}
 
 	return nil

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -39,8 +39,18 @@ func NewApp() *cobra.Command {
 	return cmd
 }
 
+// Version is stamped at build time via
+// -ldflags "-X github.com/rebellions-sw/rbln-metrics-exporter/internal/cmd.Version=...".
+var Version = "dev"
+
+// logStartup records the snapshot needed to read the rest of the logs cold:
+// which build is running and every resolved knob that shapes its behavior.
+func logStartup(cfg Config) {
+	slog.Info("Starting rbln-metrics-exporter", "version", Version, "config", cfg)
+}
+
 func Start(ctx context.Context, config Config) error {
-	slog.Info("Starting rbln-metrics-exporter", "config", config)
+	logStartup(config)
 	if os.Getenv("PROMETHEUS_METRIC_NAMES") != "true" {
 		slog.Warn(
 			"Legacy metric names are deprecated and will be removed in the next version; set PROMETHEUS_METRIC_NAMES=true to enable the new metric names",
@@ -64,7 +74,6 @@ func Start(ctx context.Context, config Config) error {
 
 	metricRegistry := prometheus.NewRegistry()
 	isKubernetes := resolveKubernetesMode(config.KubernetesMode)
-	slog.Debug("Resolved Kubernetes mode", "mode", config.KubernetesMode, "kubernetes", isKubernetes)
 	var podResourceMapper *collector.PodResourceMapper
 	if isKubernetes {
 		podResourceMapper, err = collector.NewPodResourceMapper(ctx)
@@ -113,12 +122,17 @@ func startGateway(ctx context.Context, config Config) error {
 }
 
 func resolveKubernetesMode(mode string) bool {
+	var kubernetes bool
 	switch mode {
 	case KubernetesModeOn:
-		return true
+		kubernetes = true
 	case KubernetesModeOff:
-		return false
+		kubernetes = false
 	default:
-		return collector.IsKubernetes()
+		kubernetes = collector.IsKubernetes()
 	}
+	// The resolved mode decides whether pod attribution exists at all, so it
+	// belongs in the info-level startup story, not behind the debug gate.
+	slog.Info("Resolved Kubernetes mode", "mode", mode, "kubernetes", kubernetes)
+	return kubernetes
 }

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -133,6 +133,6 @@ func resolveKubernetesMode(mode string) bool {
 	}
 	// The resolved mode decides whether pod attribution exists at all, so it
 	// belongs in the info-level startup story, not behind the debug gate.
-	slog.Info("Resolved Kubernetes mode", "mode", mode, "kubernetes", kubernetes)
+	slog.Info("Resolved Kubernetes mode", "kubernetesMode", mode, "kubernetes", kubernetes)
 	return kubernetes
 }

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/rebellions-sw/rbln-metrics-exporter/internal/logging"
+)
+
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	logger, err := logging.New(&buf, "info", "json")
+	if err != nil {
+		t.Fatalf("logging.New: %v", err)
+	}
+	old := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+func lastRecord(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("not JSON: %v: %s", err, buf.String())
+	}
+	return m
+}
+
+func TestLogStartupEmitsVersionAndReadableConfig(t *testing.T) {
+	buf := captureLogs(t)
+	logStartup(Config{
+		Mode:           ModeLocal,
+		RBLNDaemonURL:  "127.0.0.1:50051",
+		Port:           9090,
+		Interval:       5 * time.Second,
+		NodeName:       "node-1",
+		KubernetesMode: KubernetesModeAuto,
+	})
+
+	m := lastRecord(t, buf)
+	if m["msg"] != "Starting rbln-metrics-exporter" {
+		t.Fatalf("msg = %v", m["msg"])
+	}
+	if m["version"] != Version {
+		t.Fatalf("version = %v, want %q", m["version"], Version)
+	}
+	cfg, ok := m["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("config not a group: %v", m["config"])
+	}
+	for key, want := range map[string]any{
+		"mode":            "local",
+		"daemon":          "127.0.0.1:50051",
+		"port":            float64(9090),
+		"interval":        "5s",
+		"node":            "node-1",
+		"kubernetes_mode": "auto",
+	} {
+		if cfg[key] != want {
+			t.Fatalf("config.%s = %v, want %v", key, cfg[key], want)
+		}
+	}
+}
+
+func TestResolveKubernetesModeLogsResolution(t *testing.T) {
+	for _, tc := range []struct {
+		mode string
+		want bool
+	}{
+		{KubernetesModeOn, true},
+		{KubernetesModeOff, false},
+	} {
+		buf := captureLogs(t)
+		if got := resolveKubernetesMode(tc.mode); got != tc.want {
+			t.Fatalf("resolveKubernetesMode(%q) = %v, want %v", tc.mode, got, tc.want)
+		}
+		m := lastRecord(t, buf)
+		if m["level"] != "info" || m["msg"] != "Resolved Kubernetes mode" {
+			t.Fatalf("record = %v, want info resolution record", m)
+		}
+		if m["mode"] != tc.mode || m["kubernetes"] != tc.want {
+			t.Fatalf("mode/kubernetes = %v/%v, want %v/%v", m["mode"], m["kubernetes"], tc.mode, tc.want)
+		}
+	}
+}

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -55,12 +55,12 @@ func TestLogStartupEmitsVersionAndReadableConfig(t *testing.T) {
 		t.Fatalf("config not a group: %v", m["config"])
 	}
 	for key, want := range map[string]any{
-		"mode":            "local",
-		"daemon":          "127.0.0.1:50051",
-		"port":            float64(9090),
-		"interval":        "5s",
-		"node":            "node-1",
-		"kubernetes_mode": "auto",
+		"mode":           "local",
+		"daemon":         "127.0.0.1:50051",
+		"port":           float64(9090),
+		"interval":       "5s",
+		"node":           "node-1",
+		"kubernetesMode": "auto",
 	} {
 		if cfg[key] != want {
 			t.Fatalf("config.%s = %v, want %v", key, cfg[key], want)
@@ -84,8 +84,8 @@ func TestResolveKubernetesModeLogsResolution(t *testing.T) {
 		if m["level"] != "info" || m["msg"] != "Resolved Kubernetes mode" {
 			t.Fatalf("record = %v, want info resolution record", m)
 		}
-		if m["mode"] != tc.mode || m["kubernetes"] != tc.want {
-			t.Fatalf("mode/kubernetes = %v/%v, want %v/%v", m["mode"], m["kubernetes"], tc.mode, tc.want)
+		if m["kubernetesMode"] != tc.mode || m["kubernetes"] != tc.want {
+			t.Fatalf("kubernetesMode/kubernetes = %v/%v, want %v/%v", m["kubernetesMode"], m["kubernetes"], tc.mode, tc.want)
 		}
 	}
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -23,6 +24,20 @@ type Config struct {
 	Oneshot        bool
 	NodeName       string
 	KubernetesMode string
+}
+
+// LogValue renders the resolved configuration for the startup record with
+// stable lowercase keys and a human-readable interval.
+func (c Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("mode", c.Mode),
+		slog.String("daemon", c.RBLNDaemonURL),
+		slog.Int("port", c.Port),
+		slog.String("interval", c.Interval.String()),
+		slog.Bool("oneshot", c.Oneshot),
+		slog.String("node", c.NodeName),
+		slog.String("kubernetes_mode", c.KubernetesMode),
+	)
 }
 
 type configBuilder struct {

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -27,7 +27,7 @@ type Config struct {
 }
 
 // LogValue renders the resolved configuration for the startup record with
-// stable lowercase keys and a human-readable interval.
+// stable camelCase keys and a human-readable interval.
 func (c Config) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("mode", c.Mode),
@@ -36,7 +36,7 @@ func (c Config) LogValue() slog.Value {
 		slog.String("interval", c.Interval.String()),
 		slog.Bool("oneshot", c.Oneshot),
 		slog.String("node", c.NodeName),
-		slog.String("kubernetes_mode", c.KubernetesMode),
+		slog.String("kubernetesMode", c.KubernetesMode),
 	)
 }
 

--- a/internal/collector/kubernetes.go
+++ b/internal/collector/kubernetes.go
@@ -13,6 +13,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	podResourcesAPI "k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+
+	"github.com/rebellions-sw/rbln-metrics-exporter/internal/logging"
 )
 
 const (
@@ -113,11 +115,17 @@ func (p *PodResourceMapper) syncPodResources() error {
 							Namespace:     pod.Namespace,
 							ContainerName: container.Name,
 						}
+						slog.Log(context.Background(), logging.LevelTrace, "Mapped device to pod",
+							"deviceId", deviceID, "pod", pod.Name, "namespace", pod.Namespace,
+							"container", container.Name, "resource", containerDevice.GetResourceName())
 					}
 				}
 			}
 		}
 	}
+
+	slog.Debug("Synced pod resources",
+		"devices", len(podResourcesInfo), "pods", len(podResources.GetPodResources()))
 
 	p.Lock()
 	defer p.Unlock()

--- a/internal/collector/kubernetes.go
+++ b/internal/collector/kubernetes.go
@@ -49,7 +49,8 @@ func NewPodResourceMapper(ctx context.Context) (*PodResourceMapper, error) {
 	}
 
 	if err := m.syncPodResources(); err != nil {
-		slog.Warn("initial pod resource sync failed", "err", err)
+		slog.Warn("Initial pod resource sync failed", "err", err,
+			"effect", "pod attribution missing until first successful sync")
 	}
 
 	go func() {
@@ -85,7 +86,8 @@ func (p *PodResourceMapper) runSyncLoop(ctx context.Context) {
 		select {
 		case <-p.syncRequests:
 			if err := p.syncPodResources(); err != nil {
-				slog.Warn("Failed to sync pod resources", "err", err)
+				slog.Warn("Failed to sync pod resources", "err", err,
+					"effect", "pod attribution stale until next successful sync")
 			}
 		case <-ctx.Done():
 			return
@@ -137,12 +139,10 @@ func (p *PodResourceMapper) getPodResources() (*podResourcesAPI.ListPodResources
 
 func newKubeletClient() (*grpc.ClientConn, func(), error) {
 	if _, err := os.Stat(PodResourceSocket); err != nil {
-		slog.Error("kubelet pod-resources socket unavailable", "socket", PodResourceSocket, "err", err)
 		return nil, func() {}, fmt.Errorf("kubelet pod-resources socket unavailable, %w", err)
 	}
 	conn, err := grpc.NewClient("unix://"+PodResourceSocket, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		slog.Error("failed to create kubelet client", "err", err)
 		return nil, func() {}, fmt.Errorf("failed to create kubelet client, %w", err)
 	}
 	return conn, func() {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/rebellions-sw/rbln-metrics-exporter/internal/logging"
 	"github.com/rebellions-sw/rbln-metrics-exporter/pkg/rblnservicespb"
 )
 
@@ -149,6 +150,8 @@ func (c *Client) GetDeviceInfo(ctx context.Context) ([]DeviceInfo, error) {
 			di.ErrStatus = int(info.GetErrStatus())
 			di.DevState = info.GetDevStatus()
 			di.PState = info.GetPState()
+		} else {
+			slog.Debug("Device missing from total info; telemetry zeroed", "device", dev.GetName())
 		}
 
 		di.SMCVersion, err = c.getSMCVersion(ctx, dev.GetName())
@@ -157,8 +160,13 @@ func (c *Client) GetDeviceInfo(ctx context.Context) ([]DeviceInfo, error) {
 		}
 
 		merged = append(merged, di)
+		slog.Log(ctx, logging.LevelTrace, "Merged device",
+			"device", di.Name, "uuid", di.UUID, "state", di.DevState.String(),
+			"pstate", di.PState, "errStatus", di.ErrStatus)
 	}
 
+	slog.Debug("Merged device info", "devices", len(devices),
+		"totalInfos", len(totalInfos), "topologies", len(topologies), "merged", len(merged))
 	return merged, nil
 }
 

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -101,20 +101,17 @@ type DeviceInfo struct {
 func (c *Client) GetDeviceInfo(ctx context.Context) ([]DeviceInfo, error) {
 	devices, err := c.getServiceableDevices(ctx)
 	if err != nil {
-		slog.Warn("failed to get serviceable devices", "err", err)
-		return nil, fmt.Errorf("failed to get serviceable devices: %v", err)
+		return nil, fmt.Errorf("failed to get serviceable devices: %w", err)
 	}
 
 	totalInfos, err := c.getTotalDeviceInfo(ctx)
 	if err != nil {
-		slog.Warn("failed to get total device info", "err", err)
-		return nil, fmt.Errorf("failed to get total device info: %v", err)
+		return nil, fmt.Errorf("failed to get total device info: %w", err)
 	}
 
 	topologies, err := c.getTopologyByName(ctx)
 	if err != nil {
-		slog.Warn("failed to list topology", "err", err)
-		return nil, fmt.Errorf("failed to list topology: %v", err)
+		return nil, fmt.Errorf("failed to list topology: %w", err)
 	}
 
 	// Key by name, not UUID: getTotalInfo includes SR-IOV VFs, which share
@@ -156,8 +153,7 @@ func (c *Client) GetDeviceInfo(ctx context.Context) ([]DeviceInfo, error) {
 
 		di.SMCVersion, err = c.getSMCVersion(ctx, dev.GetName())
 		if err != nil {
-			slog.Warn("failed to get version", "device", dev.GetName(), "err", err)
-			return nil, fmt.Errorf("failed to get version for %s: %v", dev.GetName(), err)
+			return nil, fmt.Errorf("failed to get version for %s: %w", dev.GetName(), err)
 		}
 
 		merged = append(merged, di)
@@ -177,7 +173,7 @@ func (c *Client) getTopologyByName(ctx context.Context) (map[string]*TopologyInf
 		// A failed entry's zero values are indistinguishable from real
 		// readings (e.g. numa_node 0), so skip it entirely.
 		if entryErr := entry.GetError(); entryErr.GetCode() != 0 || entryErr.GetMessage() != "" {
-			slog.Debug("skipping topology entry with error",
+			slog.Debug("Skipping topology entry with error",
 				"device", entry.GetDeviceName(), "code", entryErr.GetCode(), "message", entryErr.GetMessage())
 			continue
 		}
@@ -198,7 +194,7 @@ func (c *Client) getSMCVersion(ctx context.Context, name string) (string, error)
 		return "", fmt.Errorf("failed to GetVersion RPC: %w", err)
 	}
 	if version.GetErrStatus() != rblnservicespb.Status_SUCCEED {
-		slog.Debug("daemon returned no version", "device", name)
+		slog.Debug("Daemon returned no version", "device", name)
 		return "", nil
 	}
 	return version.GetSmcVersion(), nil

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -182,7 +182,7 @@ func (c *Client) getTopologyByName(ctx context.Context) (map[string]*TopologyInf
 		// readings (e.g. numa_node 0), so skip it entirely.
 		if entryErr := entry.GetError(); entryErr.GetCode() != 0 || entryErr.GetMessage() != "" {
 			slog.Debug("Skipping topology entry with error",
-				"device", entry.GetDeviceName(), "code", entryErr.GetCode(), "message", entryErr.GetMessage())
+				"device", entry.GetDeviceName(), "code", entryErr.GetCode(), "errMessage", entryErr.GetMessage())
 			continue
 		}
 		topologies[entry.GetDeviceName()] = &TopologyInfo{

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -23,8 +24,28 @@ const (
 )
 
 type Client struct {
-	conn   *grpc.ClientConn
-	client rblnservicespb.RBLNServicesClient
+	conn     *grpc.ClientConn
+	client   rblnservicespb.RBLNServicesClient
+	endpoint string
+
+	// Edge-tracking state for the device-visibility records; guarded by mu
+	// because gateway mode may serve concurrent scrapes on one cached client.
+	mu            sync.Mutex
+	collectedOnce bool
+	prevMissing   map[string]bool
+	prevHealth    map[string]deviceHealth
+}
+
+// deviceHealth is the health-relevant slice of a device's state. READY/BUSY
+// activity churn is deliberately excluded so steady state stays silent in
+// the logs; the full state is always available via the device-state metric.
+type deviceHealth struct {
+	state     rblnservicespb.DeviceStatus
+	errStatus int
+}
+
+func (h deviceHealth) degraded() bool {
+	return h.state == rblnservicespb.DeviceStatus_FAULT || h.errStatus != 0
 }
 
 func NewClient(ctx context.Context, endpoint string) (*Client, error) {
@@ -44,8 +65,9 @@ func NewClient(ctx context.Context, endpoint string) (*Client, error) {
 
 	c := rblnservicespb.NewRBLNServicesClient(conn)
 	return &Client{
-		conn:   conn,
-		client: c,
+		conn:     conn,
+		client:   c,
+		endpoint: endpoint,
 	}, nil
 }
 
@@ -59,8 +81,9 @@ func NewLazyClient(endpoint string) (*Client, error) {
 	}
 
 	return &Client{
-		conn:   conn,
-		client: rblnservicespb.NewRBLNServicesClient(conn),
+		conn:     conn,
+		client:   rblnservicespb.NewRBLNServicesClient(conn),
+		endpoint: endpoint,
 	}, nil
 }
 
@@ -124,6 +147,7 @@ func (c *Client) GetDeviceInfo(ctx context.Context) ([]DeviceInfo, error) {
 	}
 
 	merged := make([]DeviceInfo, 0, len(devices))
+	missing := make(map[string]bool)
 	for _, dev := range devices {
 		di := DeviceInfo{
 			UUID:       dev.GetUuid(),
@@ -151,6 +175,7 @@ func (c *Client) GetDeviceInfo(ctx context.Context) ([]DeviceInfo, error) {
 			di.DevState = info.GetDevStatus()
 			di.PState = info.GetPState()
 		} else {
+			missing[dev.GetName()] = true
 			slog.Debug("Device missing from total info; telemetry zeroed", "device", dev.GetName())
 		}
 
@@ -167,7 +192,77 @@ func (c *Client) GetDeviceInfo(ctx context.Context) ([]DeviceInfo, error) {
 
 	slog.Debug("Merged device info", "devices", len(devices),
 		"totalInfos", len(totalInfos), "topologies", len(topologies), "merged", len(merged))
+	c.recordDeviceTransitions(merged, missing)
 	return merged, nil
+}
+
+// recordDeviceTransitions makes device-level failures diagnosable from
+// default-level logs while keeping steady state silent: every record here is
+// edge-triggered (fires once on a transition, never per cycle).
+func (c *Client) recordDeviceTransitions(merged []DeviceInfo, missing map[string]bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.collectedOnce {
+		c.collectedOnce = true
+		slog.Info("First collection succeeded", "endpoint", c.endpoint, "devices", len(merged))
+	}
+
+	serviceable := make(map[string]bool, len(merged))
+	for _, di := range merged {
+		serviceable[di.Name] = true
+	}
+
+	for name := range missing {
+		if !c.prevMissing[name] {
+			slog.Warn("Device missing from total info", "device", name,
+				"effect", "telemetry zeroed until device returns")
+		}
+	}
+	for name := range c.prevMissing {
+		if !missing[name] && serviceable[name] {
+			slog.Info("Device returned to total info", "device", name)
+		}
+	}
+
+	health := make(map[string]deviceHealth, len(merged))
+	for _, di := range merged {
+		if missing[di.Name] {
+			continue // the missing warn already covers this device
+		}
+		now := deviceHealth{state: di.DevState, errStatus: di.ErrStatus}
+		health[di.Name] = now
+		// The zero value of prev reads as healthy, so a device that is
+		// already sick on the first collection still gets its warn.
+		prev := c.prevHealth[di.Name]
+		if prev.degraded() == now.degraded() {
+			continue
+		}
+		if now.degraded() {
+			slog.Warn("Device entered degraded state", "device", di.Name,
+				"state", now.state.String(), "errStatus", now.errStatus)
+		} else {
+			slog.Info("Device recovered", "device", di.Name, "state", now.state.String())
+		}
+	}
+
+	// prevHealth and prevMissing are disjoint (a missing device is never in
+	// health), so a vanished device warns exactly once.
+	for name := range c.prevHealth {
+		if !serviceable[name] {
+			slog.Warn("Device no longer serviceable", "device", name,
+				"effect", "metrics for this device are no longer exported")
+		}
+	}
+	for name := range c.prevMissing {
+		if !serviceable[name] {
+			slog.Warn("Device no longer serviceable", "device", name,
+				"effect", "metrics for this device are no longer exported")
+		}
+	}
+
+	c.prevMissing = missing
+	c.prevHealth = health
 }
 
 func (c *Client) getTopologyByName(ctx context.Context) (map[string]*TopologyInfo, error) {

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -1,0 +1,294 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	"github.com/rebellions-sw/rbln-metrics-exporter/internal/logging"
+	"github.com/rebellions-sw/rbln-metrics-exporter/pkg/rblnservicespb"
+)
+
+// fakeDaemon serves the RPC surface GetDeviceInfo touches, with a mutable
+// device/total-info view so tests can drive per-cycle transitions.
+type fakeDaemon struct {
+	rblnservicespb.UnimplementedRBLNServicesServer
+	mu          sync.Mutex
+	serviceable []*rblnservicespb.Device
+	totalInfos  []*rblnservicespb.DeviceInfo
+}
+
+func (f *fakeDaemon) set(devices []*rblnservicespb.Device, infos []*rblnservicespb.DeviceInfo) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.serviceable, f.totalInfos = devices, infos
+}
+
+func (f *fakeDaemon) GetServiceableDeviceList(_ *rblnservicespb.Empty, stream grpc.ServerStreamingServer[rblnservicespb.Device]) error {
+	f.mu.Lock()
+	devices := append([]*rblnservicespb.Device(nil), f.serviceable...)
+	f.mu.Unlock()
+	for _, d := range devices {
+		if err := stream.Send(d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeDaemon) GetTotalInfo(_ *rblnservicespb.Empty, stream grpc.ServerStreamingServer[rblnservicespb.DeviceInfo]) error {
+	f.mu.Lock()
+	infos := append([]*rblnservicespb.DeviceInfo(nil), f.totalInfos...)
+	f.mu.Unlock()
+	for _, i := range infos {
+		if err := stream.Send(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeDaemon) GetVersion(context.Context, *rblnservicespb.Device) (*rblnservicespb.VersionInfo, error) {
+	return &rblnservicespb.VersionInfo{ErrStatus: rblnservicespb.Status_SUCCEED, SmcVersion: "1.0.0"}, nil
+}
+
+func (f *fakeDaemon) RblnListTopology(context.Context, *rblnservicespb.DeviceFilter) (*rblnservicespb.RblnListTopologyResponse, error) {
+	return &rblnservicespb.RblnListTopologyResponse{}, nil
+}
+
+func startFake(t *testing.T, fake *fakeDaemon) *Client {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	rblnservicespb.RegisterRBLNServicesServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	client, err := NewLazyClient(lis.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	logger, err := logging.New(&buf, "info", "json")
+	if err != nil {
+		t.Fatalf("logging.New: %v", err)
+	}
+	old := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+func jsonRecords(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var recs []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("not JSON: %v: %s", err, line)
+		}
+		recs = append(recs, m)
+	}
+	return recs
+}
+
+func recordsWithMsg(recs []map[string]any, msg string) []map[string]any {
+	var out []map[string]any
+	for _, m := range recs {
+		if m["msg"] == msg {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func dev(name string) *rblnservicespb.Device {
+	return &rblnservicespb.Device{Name: name, Uuid: "uuid-" + name}
+}
+
+func info(name string, status rblnservicespb.DeviceStatus, errStatus rblnservicespb.Status) *rblnservicespb.DeviceInfo {
+	return &rblnservicespb.DeviceInfo{Name: name, DevStatus: status, ErrStatus: errStatus}
+}
+
+func collect(t *testing.T, c *Client) {
+	t.Helper()
+	if _, err := c.GetDeviceInfo(context.Background()); err != nil {
+		t.Fatalf("GetDeviceInfo: %v", err)
+	}
+}
+
+func TestGetDeviceInfoLogsFirstSuccessOnce(t *testing.T) {
+	fake := &fakeDaemon{}
+	fake.set(
+		[]*rblnservicespb.Device{dev("rbln0"), dev("rbln1")},
+		[]*rblnservicespb.DeviceInfo{
+			info("rbln0", rblnservicespb.DeviceStatus_READY, rblnservicespb.Status_SUCCEED),
+			info("rbln1", rblnservicespb.DeviceStatus_READY, rblnservicespb.Status_SUCCEED),
+		},
+	)
+	client := startFake(t, fake)
+	buf := captureLogs(t)
+
+	collect(t, client)
+	collect(t, client)
+
+	recs := recordsWithMsg(jsonRecords(t, buf), "First collection succeeded")
+	if len(recs) != 1 {
+		t.Fatalf("got %d first-success records, want 1: %s", len(recs), buf.String())
+	}
+	m := recs[0]
+	if m["level"] != "info" || m["devices"] != float64(2) {
+		t.Fatalf("record = %v, want info with devices=2", m)
+	}
+	if ep, ok := m["endpoint"].(string); !ok || ep == "" {
+		t.Fatalf("endpoint = %v, want non-empty daemon endpoint", m["endpoint"])
+	}
+}
+
+func TestGetDeviceInfoMissingDeviceEdges(t *testing.T) {
+	present := []*rblnservicespb.DeviceInfo{
+		info("rbln0", rblnservicespb.DeviceStatus_READY, rblnservicespb.Status_SUCCEED),
+	}
+	fake := &fakeDaemon{}
+	fake.set([]*rblnservicespb.Device{dev("rbln0")}, present)
+	client := startFake(t, fake)
+	buf := captureLogs(t)
+
+	collect(t, client) // healthy baseline
+	fake.set([]*rblnservicespb.Device{dev("rbln0")}, nil)
+	collect(t, client) // goes missing -> one warn
+	collect(t, client) // still missing -> no repeat
+	fake.set([]*rblnservicespb.Device{dev("rbln0")}, present)
+	collect(t, client) // returns -> one info
+
+	recs := jsonRecords(t, buf)
+	missing := recordsWithMsg(recs, "Device missing from total info")
+	if len(missing) != 1 {
+		t.Fatalf("got %d missing warns, want 1 (edge-triggered): %s", len(missing), buf.String())
+	}
+	m := missing[0]
+	if m["level"] != "warn" || m["device"] != "rbln0" {
+		t.Fatalf("record = %v, want warn for rbln0", m)
+	}
+	if _, ok := m["effect"].(string); !ok {
+		t.Fatalf("effect = %v, want degradation effect string", m["effect"])
+	}
+	returned := recordsWithMsg(recs, "Device returned to total info")
+	if len(returned) != 1 || returned[0]["device"] != "rbln0" {
+		t.Fatalf("got %d returned records, want 1 for rbln0: %s", len(returned), buf.String())
+	}
+}
+
+func TestGetDeviceInfoDegradedEdges(t *testing.T) {
+	devices := []*rblnservicespb.Device{dev("rbln0")}
+	fake := &fakeDaemon{}
+	fake.set(devices, []*rblnservicespb.DeviceInfo{
+		info("rbln0", rblnservicespb.DeviceStatus_READY, rblnservicespb.Status_SUCCEED),
+	})
+	client := startFake(t, fake)
+	buf := captureLogs(t)
+
+	collect(t, client) // healthy baseline
+	fake.set(devices, []*rblnservicespb.DeviceInfo{
+		info("rbln0", rblnservicespb.DeviceStatus_BUSY, rblnservicespb.Status_SUCCEED),
+	})
+	collect(t, client) // READY->BUSY churn must stay silent
+	fake.set(devices, []*rblnservicespb.DeviceInfo{
+		info("rbln0", rblnservicespb.DeviceStatus_FAULT, rblnservicespb.Status_FAILED),
+	})
+	collect(t, client) // degrades -> one warn
+	collect(t, client) // still degraded -> no repeat
+	fake.set(devices, []*rblnservicespb.DeviceInfo{
+		info("rbln0", rblnservicespb.DeviceStatus_READY, rblnservicespb.Status_SUCCEED),
+	})
+	collect(t, client) // recovers -> one info
+
+	recs := jsonRecords(t, buf)
+	degraded := recordsWithMsg(recs, "Device entered degraded state")
+	if len(degraded) != 1 {
+		t.Fatalf("got %d degraded warns, want 1 (edge-triggered, silent on READY->BUSY): %s",
+			len(degraded), buf.String())
+	}
+	m := degraded[0]
+	if m["level"] != "warn" || m["device"] != "rbln0" {
+		t.Fatalf("record = %v, want warn for rbln0", m)
+	}
+	if m["state"] != "FAULT" || m["errStatus"] != float64(rblnservicespb.Status_FAILED) {
+		t.Fatalf("state/errStatus = %v/%v, want FAULT/1", m["state"], m["errStatus"])
+	}
+	recovered := recordsWithMsg(recs, "Device recovered")
+	if len(recovered) != 1 || recovered[0]["device"] != "rbln0" {
+		t.Fatalf("got %d recovered records, want 1 for rbln0: %s", len(recovered), buf.String())
+	}
+}
+
+func TestGetDeviceInfoDegradedVisibleOnFirstCollection(t *testing.T) {
+	fake := &fakeDaemon{}
+	fake.set([]*rblnservicespb.Device{dev("rbln0")}, []*rblnservicespb.DeviceInfo{
+		info("rbln0", rblnservicespb.DeviceStatus_FAULT, rblnservicespb.Status_FAILED),
+	})
+	client := startFake(t, fake)
+	buf := captureLogs(t)
+
+	collect(t, client) // a device that is already sick at startup must be visible
+
+	degraded := recordsWithMsg(jsonRecords(t, buf), "Device entered degraded state")
+	if len(degraded) != 1 {
+		t.Fatalf("got %d degraded warns, want 1 on first collection: %s", len(degraded), buf.String())
+	}
+}
+
+func TestGetDeviceInfoVanishedDeviceWarnsOnce(t *testing.T) {
+	fake := &fakeDaemon{}
+	fake.set(
+		[]*rblnservicespb.Device{dev("rbln0"), dev("rbln1")},
+		[]*rblnservicespb.DeviceInfo{
+			info("rbln0", rblnservicespb.DeviceStatus_READY, rblnservicespb.Status_SUCCEED),
+			info("rbln1", rblnservicespb.DeviceStatus_READY, rblnservicespb.Status_SUCCEED),
+		},
+	)
+	client := startFake(t, fake)
+	buf := captureLogs(t)
+
+	collect(t, client) // baseline: two devices
+	fake.set(
+		[]*rblnservicespb.Device{dev("rbln0")},
+		[]*rblnservicespb.DeviceInfo{
+			info("rbln0", rblnservicespb.DeviceStatus_READY, rblnservicespb.Status_SUCCEED),
+		},
+	)
+	collect(t, client) // rbln1 falls off the serviceable list -> one warn
+	collect(t, client) // still gone -> no repeat
+
+	recs := jsonRecords(t, buf)
+	vanished := recordsWithMsg(recs, "Device no longer serviceable")
+	if len(vanished) != 1 {
+		t.Fatalf("got %d vanished warns, want 1: %s", len(vanished), buf.String())
+	}
+	m := vanished[0]
+	if m["level"] != "warn" || m["device"] != "rbln1" {
+		t.Fatalf("record = %v, want warn for rbln1", m)
+	}
+	if returned := recordsWithMsg(recs, "Device returned to total info"); len(returned) != 0 {
+		t.Fatalf("vanished device must not be reported as returned: %v", returned)
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -71,7 +71,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	up.Set(1)
 	for _, c := range collectorFactory.NewCollectors() {
 		if err := c.GetMetrics(ctx); err != nil {
-			slog.Warn("gateway collect failed", "target", target, "err", err)
+			slog.Warn("Gateway collect failed", "target", target, "err", err,
+				"effect", "scrape returns rbln_up 0")
 			up.Set(0)
 			break
 		}
@@ -85,7 +86,8 @@ func (h *Handler) Close() {
 	defer h.mu.Unlock()
 	for target, client := range h.clients {
 		if err := client.Close(); err != nil {
-			slog.Warn("failed to close daemon client", "target", target, "err", err)
+			slog.Warn("Failed to close daemon client", "target", target, "err", err,
+				"effect", "connection may leak until process exit")
 		}
 	}
 	clear(h.clients)

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -39,16 +39,19 @@ func NewHandler() *Handler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	target := stripSchemePrefix(r.URL.Query().Get("target"))
 	if target == "" {
+		slog.Debug("Rejected scrape request", "reason", "missing target parameter")
 		http.Error(w, "missing required parameter: target=<host:port> of an rbln-smd grpc endpoint", http.StatusBadRequest)
 		return
 	}
 	if _, _, err := net.SplitHostPort(target); err != nil {
+		slog.Debug("Rejected scrape request", "target", target, "err", err)
 		http.Error(w, fmt.Sprintf("invalid target %q: expected <host:port>: %v", target, err), http.StatusBadRequest)
 		return
 	}
 
 	client, err := h.clientFor(target)
 	if err != nil {
+		slog.Debug("Rejected scrape request", "target", target, "err", err)
 		http.Error(w, fmt.Sprintf("invalid target %q: %v", target, err), http.StatusBadRequest)
 		return
 	}
@@ -65,7 +68,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		false,
 	)
 
-	ctx, cancel := context.WithTimeout(r.Context(), scrapeTimeout(r))
+	timeout := scrapeTimeout(r)
+	slog.Debug("Scraping gateway target",
+		"target", target, "timeout", timeout.String(), "host", hostLabel(target))
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()
 
 	up.Set(1)
@@ -98,6 +104,7 @@ func (h *Handler) clientFor(target string) (*daemon.Client, error) {
 	defer h.mu.Unlock()
 
 	if client, ok := h.clients[target]; ok {
+		slog.Debug("Reusing cached daemon client", "target", target)
 		return client, nil
 	}
 	client, err := daemon.NewLazyClient(target)
@@ -105,6 +112,7 @@ func (h *Handler) clientFor(target string) (*daemon.Client, error) {
 		return nil, err
 	}
 	h.clients[target] = client
+	slog.Debug("Created daemon client", "target", target)
 	return client, nil
 }
 

--- a/internal/logging/grpclog.go
+++ b/internal/logging/grpclog.go
@@ -1,0 +1,71 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc/grpclog"
+)
+
+// grpcLogger routes gRPC-internal records to the slog default logger.
+// grpclog's own default writes plain text to stderr through private
+// log.Loggers that bypass the stdlib-log bridge, contaminating the
+// single-line JSON stream that log pipelines parse. Transport chatter
+// (info/warning severity) maps to debug; only genuine errors surface at
+// error level.
+type grpcLogger struct{}
+
+func redirectGrpclog() {
+	grpclog.SetLoggerV2(grpcLogger{})
+}
+
+func (grpcLogger) Info(args ...any) { grpcLog(slog.LevelDebug, "info", fmt.Sprint(args...)) }
+
+func (grpcLogger) Infoln(args ...any) { grpcLog(slog.LevelDebug, "info", sprintln(args)) }
+
+func (grpcLogger) Infof(format string, args ...any) {
+	grpcLog(slog.LevelDebug, "info", fmt.Sprintf(format, args...))
+}
+
+func (grpcLogger) Warning(args ...any) { grpcLog(slog.LevelDebug, "warning", fmt.Sprint(args...)) }
+
+func (grpcLogger) Warningln(args ...any) { grpcLog(slog.LevelDebug, "warning", sprintln(args)) }
+
+func (grpcLogger) Warningf(format string, args ...any) {
+	grpcLog(slog.LevelDebug, "warning", fmt.Sprintf(format, args...))
+}
+
+func (grpcLogger) Error(args ...any) { grpcLog(slog.LevelError, "error", fmt.Sprint(args...)) }
+
+func (grpcLogger) Errorln(args ...any) { grpcLog(slog.LevelError, "error", sprintln(args)) }
+
+func (grpcLogger) Errorf(format string, args ...any) {
+	grpcLog(slog.LevelError, "error", fmt.Sprintf(format, args...))
+}
+
+// Fatal must exit per the grpclog.LoggerV2 contract.
+func (grpcLogger) Fatal(args ...any) {
+	grpcLog(slog.LevelError, "fatal", fmt.Sprint(args...))
+	os.Exit(1)
+}
+
+func (grpcLogger) Fatalln(args ...any) { grpcLog(slog.LevelError, "fatal", sprintln(args)); os.Exit(1) }
+
+func (grpcLogger) Fatalf(format string, args ...any) {
+	grpcLog(slog.LevelError, "fatal", fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+// V mirrors grpclog's default verbosity of 0.
+func (grpcLogger) V(l int) bool { return l <= 0 }
+
+func grpcLog(level slog.Level, severity, detail string) {
+	slog.Log(context.Background(), level, "gRPC log", "severity", severity, "detail", detail)
+}
+
+func sprintln(args []any) string {
+	return strings.TrimSuffix(fmt.Sprintln(args...), "\n")
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,9 +1,6 @@
-// Package logging configures the process-wide slog logger according to the
-// RBLN logging contract (rbln-npu-operator/docs/logging.md).
-//
-// Canonical copy — 수정 시 모든 repo의 복사본을 함께 갱신할 것:
-// rbln-metrics-exporter, rbln-npu-feature-discovery, rbln-k8s-driver-manager,
-// sandbox-device-plugin, rbln-npu-operator.
+// Package logging configures the process-wide slog logger: structured json
+// or text records controlled by LOG_LEVEL and LOG_FORMAT, defaulting to
+// info/json.
 package logging
 
 import (
@@ -15,10 +12,10 @@ import (
 	"time"
 )
 
-// LevelTrace extends slog's levels downward for the contract's "trace" level.
+// LevelTrace extends slog's levels downward with a "trace" level below debug.
 const LevelTrace = slog.Level(-8)
 
-// New builds a contract-conformant slog logger writing to w.
+// New builds a slog logger writing to w.
 // level: "error"|"warning"|"info"|"debug"|"trace" ("" = info).
 // format: "json"|"text" ("" = json).
 func New(w io.Writer, level, format string) (*slog.Logger, error) {
@@ -28,7 +25,7 @@ func New(w io.Writer, level, format string) (*slog.Logger, error) {
 	}
 	opts := &slog.HandlerOptions{
 		Level: lvl,
-		// caller 비용/노이즈는 debug 이상에서만 감수한다.
+		// Caller info is only worth its cost/noise at debug and trace verbosity.
 		AddSource:   lvl <= slog.LevelDebug,
 		ReplaceAttr: replaceAttr,
 	}
@@ -46,21 +43,16 @@ func New(w io.Writer, level, format string) (*slog.Logger, error) {
 	return slog.New(h), nil
 }
 
-// Setup installs the process-wide default logger (stdout).
-func Setup(level, format string) error {
-	logger, err := New(os.Stdout, level, format)
-	if err != nil {
-		return err
-	}
-	slog.SetDefault(logger)
-	return nil
+// SetupFromEnv reads LOG_LEVEL / LOG_FORMAT and installs the logger.
+// Empty values mean info/json (production defaults). Invalid values do not
+// kill the process — a typo in a DaemonSet env would CrashLoopBackOff the
+// exporter and drop all telemetry from the node. Instead, only the offending
+// variable falls back to its default, recorded by a Warn with a "fallback" key.
+func SetupFromEnv() {
+	setupFromEnv(os.Stdout)
 }
 
-// SetupFromEnv reads LOG_LEVEL / LOG_FORMAT and installs the logger.
-// 빈 값이면 info/json (프로덕션 기본). Invalid 값은 프로세스를 죽이지 않는다:
-// 해당 변수만 계약 기본값으로 대체하고, 설치된 로거로 "fallback" 키를 담은
-// Warn을 남긴다 (contract: substituting a default adds a fallback key).
-func SetupFromEnv() {
+func setupFromEnv(w io.Writer) {
 	level, format := os.Getenv("LOG_LEVEL"), os.Getenv("LOG_FORMAT")
 	var levelErr, formatErr error
 	if _, err := parseLevel(level); err != nil {
@@ -69,13 +61,16 @@ func SetupFromEnv() {
 	if _, err := parseFormat(format); err != nil {
 		formatErr, format = err, "json"
 	}
-	if err := Setup(level, format); err != nil {
-		// 위에서 검증/대체했으므로 도달 불가.
+	logger, err := New(w, level, format)
+	if err != nil {
+		// Unreachable: both inputs were validated or substituted above.
 		slog.Error("Failed to install logger", "err", err)
 		return
 	}
-	// LOG_LEVEL=error + invalid LOG_FORMAT이면 format Warn이 게이트에 억제된다 —
-	// 명시적으로 error 게이트를 고른 결과이므로 수용.
+	slog.SetDefault(logger)
+	// With LOG_LEVEL=error and an invalid LOG_FORMAT, the format Warn is
+	// suppressed by the level gate — accepted, since the error gate was
+	// explicitly requested.
 	if levelErr != nil {
 		slog.Warn("Invalid LOG_LEVEL, using default", "err", levelErr, "fallback", "info")
 	}
@@ -110,16 +105,19 @@ func parseFormat(s string) (string, error) {
 	return "", fmt.Errorf("unknown log format %q (json|text)", s)
 }
 
-// replaceAttr normalizes slog output to the contract: key "ts" with
-// RFC3339Nano, lowercase "level" ("trace" for LevelTrace), and a zap-style
-// "caller" ("file:line") instead of the verbose source group.
+// replaceAttr normalizes slog output: key "ts" with RFC3339Nano, lowercase
+// "level" ("trace" for LevelTrace), and a zap-style "caller" ("file:line")
+// instead of the verbose source group.
 func replaceAttr(groups []string, a slog.Attr) slog.Attr {
 	if len(groups) > 0 {
 		return a
 	}
 	switch a.Key {
 	case slog.TimeKey:
-		// 사용자 attr가 "time" 키를 쓸 수 있다 — 레코드 타임스탬프만 변환한다.
+		// A user attr may also use the "time" key — convert only the record
+		// timestamp. Residual limitation: a user "time" attr that is itself
+		// KindTime is indistinguishable from the record timestamp, so it is
+		// also renamed, duplicating the "ts" key in that record.
 		if a.Value.Kind() != slog.KindTime {
 			return a
 		}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -68,6 +68,7 @@ func setupFromEnv(w io.Writer) {
 		return
 	}
 	slog.SetDefault(logger)
+	redirectGrpclog()
 	// With LOG_LEVEL=error and an invalid LOG_FORMAT, the format Warn is
 	// suppressed by the level gate — accepted, since the error gate was
 	// explicitly requested.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,159 @@
+// Package logging configures the process-wide slog logger according to the
+// RBLN logging contract (rbln-npu-operator/docs/logging.md).
+//
+// Canonical copy — 수정 시 모든 repo의 복사본을 함께 갱신할 것:
+// rbln-metrics-exporter, rbln-npu-feature-discovery, rbln-k8s-driver-manager,
+// sandbox-device-plugin, rbln-npu-operator.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+)
+
+// LevelTrace extends slog's levels downward for the contract's "trace" level.
+const LevelTrace = slog.Level(-8)
+
+// New builds a contract-conformant slog logger writing to w.
+// level: "error"|"warning"|"info"|"debug"|"trace" ("" = info).
+// format: "json"|"text" ("" = json).
+func New(w io.Writer, level, format string) (*slog.Logger, error) {
+	lvl, err := parseLevel(level)
+	if err != nil {
+		return nil, err
+	}
+	opts := &slog.HandlerOptions{
+		Level: lvl,
+		// caller 비용/노이즈는 debug 이상에서만 감수한다.
+		AddSource:   lvl <= slog.LevelDebug,
+		ReplaceAttr: replaceAttr,
+	}
+	f, err := parseFormat(format)
+	if err != nil {
+		return nil, err
+	}
+	var h slog.Handler
+	switch f {
+	case "json":
+		h = slog.NewJSONHandler(w, opts)
+	case "text":
+		h = slog.NewTextHandler(w, opts)
+	}
+	return slog.New(h), nil
+}
+
+// Setup installs the process-wide default logger (stdout).
+func Setup(level, format string) error {
+	logger, err := New(os.Stdout, level, format)
+	if err != nil {
+		return err
+	}
+	slog.SetDefault(logger)
+	return nil
+}
+
+// SetupFromEnv reads LOG_LEVEL / LOG_FORMAT and installs the logger.
+// 빈 값이면 info/json (프로덕션 기본). Invalid 값은 프로세스를 죽이지 않는다:
+// 해당 변수만 계약 기본값으로 대체하고, 설치된 로거로 "fallback" 키를 담은
+// Warn을 남긴다 (contract: substituting a default adds a fallback key).
+func SetupFromEnv() {
+	level, format := os.Getenv("LOG_LEVEL"), os.Getenv("LOG_FORMAT")
+	var levelErr, formatErr error
+	if _, err := parseLevel(level); err != nil {
+		levelErr, level = err, "info"
+	}
+	if _, err := parseFormat(format); err != nil {
+		formatErr, format = err, "json"
+	}
+	if err := Setup(level, format); err != nil {
+		// 위에서 검증/대체했으므로 도달 불가.
+		slog.Error("Failed to install logger", "err", err)
+		return
+	}
+	// LOG_LEVEL=error + invalid LOG_FORMAT이면 format Warn이 게이트에 억제된다 —
+	// 명시적으로 error 게이트를 고른 결과이므로 수용.
+	if levelErr != nil {
+		slog.Warn("Invalid LOG_LEVEL, using default", "err", levelErr, "fallback", "info")
+	}
+	if formatErr != nil {
+		slog.Warn("Invalid LOG_FORMAT, using default", "err", formatErr, "fallback", "json")
+	}
+}
+
+func parseLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "error":
+		return slog.LevelError, nil
+	case "warning":
+		return slog.LevelWarn, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "trace":
+		return LevelTrace, nil
+	}
+	return 0, fmt.Errorf("unknown log level %q (error|warning|info|debug|trace)", s)
+}
+
+func parseFormat(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "json":
+		return "json", nil
+	case "text":
+		return "text", nil
+	}
+	return "", fmt.Errorf("unknown log format %q (json|text)", s)
+}
+
+// replaceAttr normalizes slog output to the contract: key "ts" with
+// RFC3339Nano, lowercase "level" ("trace" for LevelTrace), and a zap-style
+// "caller" ("file:line") instead of the verbose source group.
+func replaceAttr(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) > 0 {
+		return a
+	}
+	switch a.Key {
+	case slog.TimeKey:
+		// 사용자 attr가 "time" 키를 쓸 수 있다 — 레코드 타임스탬프만 변환한다.
+		if a.Value.Kind() != slog.KindTime {
+			return a
+		}
+		a.Key = "ts"
+		a.Value = slog.StringValue(a.Value.Time().Format(time.RFC3339Nano))
+	case slog.LevelKey:
+		lvl, ok := a.Value.Any().(slog.Level)
+		if !ok {
+			return a
+		}
+		if lvl == LevelTrace {
+			a.Value = slog.StringValue("trace")
+		} else {
+			a.Value = slog.StringValue(strings.ToLower(lvl.String()))
+		}
+	case slog.SourceKey:
+		src, ok := a.Value.Any().(*slog.Source)
+		if !ok {
+			return a
+		}
+		a.Key = "caller"
+		a.Value = slog.StringValue(fmt.Sprintf("%s:%d", trimPath(src.File), src.Line))
+	}
+	return a
+}
+
+// trimPath keeps at most the last two path segments for a zap-style short caller.
+func trimPath(file string) string {
+	idx := strings.LastIndexByte(file, '/')
+	if idx == -1 {
+		return file
+	}
+	if idx2 := strings.LastIndexByte(file[:idx], '/'); idx2 != -1 {
+		return file[idx2+1:]
+	}
+	return file
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -37,7 +37,7 @@ func logLine(t *testing.T, level, format, emit string) map[string]any {
 	return m
 }
 
-func TestNewDefaultsToInfoJSONWithContractKeys(t *testing.T) {
+func TestNewDefaultsToInfoJSON(t *testing.T) {
 	m := logLine(t, "", "", "info")
 	if m == nil {
 		t.Fatal("info line suppressed at default level")
@@ -164,17 +164,106 @@ func TestTrimPath(t *testing.T) {
 	}
 }
 
+func jsonLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var recs []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("not JSON: %v: %s", err, line)
+		}
+		recs = append(recs, m)
+	}
+	return recs
+}
+
 func TestSetupFromEnvFallsBack(t *testing.T) {
 	old := slog.Default()
 	defer slog.SetDefault(old)
 	t.Setenv("LOG_LEVEL", "bogus")
 	t.Setenv("LOG_FORMAT", "json")
-	SetupFromEnv()
+	var buf bytes.Buffer
+	setupFromEnv(&buf)
 	ctx := context.Background()
 	if !slog.Default().Enabled(ctx, slog.LevelInfo) {
 		t.Fatal("fallback logger must enable info")
 	}
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
 		t.Fatal("fallback logger must gate debug (info default)")
+	}
+}
+
+func TestSetupFromEnvWarnsFallbackRecordOnInvalidLevel(t *testing.T) {
+	old := slog.Default()
+	defer slog.SetDefault(old)
+	t.Setenv("LOG_LEVEL", "bogus")
+	t.Setenv("LOG_FORMAT", "json")
+	var buf bytes.Buffer
+	setupFromEnv(&buf)
+	recs := jsonLines(t, &buf)
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1 fallback warn: %s", len(recs), buf.String())
+	}
+	m := recs[0]
+	if m["level"] != "warn" || m["msg"] != "Invalid LOG_LEVEL, using default" {
+		t.Fatalf("record = %v, want LOG_LEVEL fallback warn", m)
+	}
+	if m["fallback"] != "info" {
+		t.Fatalf("fallback = %v, want info", m["fallback"])
+	}
+	errStr, ok := m["err"].(string)
+	if !ok || !strings.Contains(errStr, "bogus") {
+		t.Fatalf("err = %v, want message naming the rejected value", m["err"])
+	}
+}
+
+func TestSetupFromEnvWarnsFallbackRecordOnInvalidFormat(t *testing.T) {
+	old := slog.Default()
+	defer slog.SetDefault(old)
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("LOG_FORMAT", "xml")
+	var buf bytes.Buffer
+	setupFromEnv(&buf)
+	recs := jsonLines(t, &buf)
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1 fallback warn: %s", len(recs), buf.String())
+	}
+	m := recs[0]
+	if m["level"] != "warn" || m["msg"] != "Invalid LOG_FORMAT, using default" {
+		t.Fatalf("record = %v, want LOG_FORMAT fallback warn", m)
+	}
+	if m["fallback"] != "json" {
+		t.Fatalf("fallback = %v, want json", m["fallback"])
+	}
+	if _, ok := m["err"].(string); !ok {
+		t.Fatalf("err = %v, want string", m["err"])
+	}
+}
+
+func TestParseInputsTolerateWhitespaceAndCase(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want slog.Level
+	}{
+		{" INFO ", slog.LevelInfo},
+		{"Warning", slog.LevelWarn},
+		{"TRACE", LevelTrace},
+	} {
+		got, err := parseLevel(tc.in)
+		if err != nil || got != tc.want {
+			t.Errorf("parseLevel(%q) = %v, %v, want %v", tc.in, got, err, tc.want)
+		}
+	}
+	for _, tc := range []struct{ in, want string }{
+		{" JSON ", "json"},
+		{"Text", "text"},
+	} {
+		got, err := parseFormat(tc.in)
+		if err != nil || got != tc.want {
+			t.Errorf("parseFormat(%q) = %v, %v, want %q", tc.in, got, err, tc.want)
+		}
 	}
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,180 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func logLine(t *testing.T, level, format, emit string) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	logger, err := New(&buf, level, format)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	switch emit {
+	case "info":
+		logger.Info("Started component", "port", 8080)
+	case "debug":
+		logger.Debug("Polled daemon", "count", 3)
+	case "trace":
+		logger.Log(context.Background(), LevelTrace, "Dumped payload", "bytes", 42)
+	case "error":
+		logger.Error("Request failed", "err", "boom")
+	}
+	if buf.Len() == 0 {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("not JSON: %v: %s", err, buf.String())
+	}
+	return m
+}
+
+func TestNewDefaultsToInfoJSONWithContractKeys(t *testing.T) {
+	m := logLine(t, "", "", "info")
+	if m == nil {
+		t.Fatal("info line suppressed at default level")
+	}
+	if m["level"] != "info" {
+		t.Fatalf("level = %v, want info (lowercase)", m["level"])
+	}
+	if m["msg"] != "Started component" {
+		t.Fatalf("msg = %v", m["msg"])
+	}
+	if _, ok := m["ts"].(string); !ok {
+		t.Fatalf("ts missing or not string: %v", m["ts"])
+	}
+	if !strings.Contains(m["ts"].(string), "T") {
+		t.Fatalf("ts not RFC3339: %v", m["ts"])
+	}
+	if _, ok := m["caller"]; ok {
+		t.Fatal("caller must be absent at info level")
+	}
+}
+
+func TestNewGatesDebugAtInfo(t *testing.T) {
+	if m := logLine(t, "info", "json", "debug"); m != nil {
+		t.Fatalf("debug line leaked at info level: %v", m)
+	}
+}
+
+func TestNewTraceLevelRendersTraceAndCaller(t *testing.T) {
+	m := logLine(t, "trace", "json", "trace")
+	if m == nil {
+		t.Fatal("trace line suppressed at trace level")
+	}
+	if m["level"] != "trace" {
+		t.Fatalf("level = %v, want trace", m["level"])
+	}
+	if _, ok := m["caller"].(string); !ok {
+		t.Fatal("caller must be present at trace level")
+	}
+}
+
+func TestNewRejectsUnknownLevelAndFormat(t *testing.T) {
+	if _, err := New(&bytes.Buffer{}, "loud", "json"); err == nil {
+		t.Fatal("want error for unknown level")
+	}
+	if _, err := New(&bytes.Buffer{}, "info", "yaml"); err == nil {
+		t.Fatal("want error for unknown format")
+	}
+}
+
+func TestNewPassesThroughUserTimeAttr(t *testing.T) {
+	var buf bytes.Buffer
+	logger, err := New(&buf, "info", "json")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	logger.Info("Measured duration", "time", "1.5s")
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("not JSON: %v: %s", err, buf.String())
+	}
+	if m["time"] != "1.5s" {
+		t.Fatalf(`user "time" attr = %v, want "1.5s"`, m["time"])
+	}
+}
+
+func TestNewTextFormat(t *testing.T) {
+	var buf bytes.Buffer
+	logger, err := New(&buf, "", "text")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	logger.Info("Started component", "port", 8080)
+	out := buf.String()
+	for _, want := range []string{"level=info", `msg="Started component"`, "ts=", "port=8080"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text output missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestNewWarningSpelledWarnInOutput(t *testing.T) {
+	var buf bytes.Buffer
+	logger, err := New(&buf, "warning", "json")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	logger.Warn("Request failed")
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("not JSON: %v: %s", err, buf.String())
+	}
+	if m["level"] != "warn" {
+		t.Fatalf("level = %v, want warn (output spelling)", m["level"])
+	}
+	if _, err := New(&bytes.Buffer{}, "warn", "json"); err == nil {
+		t.Fatal(`want error for input "warn" — configuration vocabulary is "warning"`)
+	}
+}
+
+func TestNewCallerPresentAtDebugGate(t *testing.T) {
+	m := logLine(t, "debug", "json", "info")
+	if m == nil {
+		t.Fatal("info line suppressed at debug level")
+	}
+	caller, ok := m["caller"].(string)
+	if !ok {
+		t.Fatal("caller must be present at debug gate")
+	}
+	if !regexp.MustCompile(`^[^/]+/[^/]+\.go:\d+$`).MatchString(caller) {
+		t.Fatalf("caller = %q, want dir/file.go:N", caller)
+	}
+}
+
+func TestTrimPath(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"c.go", "c.go"},
+		{"b/c.go", "b/c.go"},
+		{"a/b/c.go", "b/c.go"},
+		{"x/a/b/c.go", "b/c.go"},
+	} {
+		if got := trimPath(tc.in); got != tc.want {
+			t.Errorf("trimPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSetupFromEnvFallsBack(t *testing.T) {
+	old := slog.Default()
+	defer slog.SetDefault(old)
+	t.Setenv("LOG_LEVEL", "bogus")
+	t.Setenv("LOG_FORMAT", "json")
+	SetupFromEnv()
+	ctx := context.Background()
+	if !slog.Default().Enabled(ctx, slog.LevelInfo) {
+		t.Fatal("fallback logger must enable info")
+	}
+	if slog.Default().Enabled(ctx, slog.LevelDebug) {
+		t.Fatal("fallback logger must gate debug (info default)")
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"google.golang.org/grpc/grpclog"
 )
 
 func logLine(t *testing.T, level, format, emit string) map[string]any {
@@ -240,6 +242,34 @@ func TestSetupFromEnvWarnsFallbackRecordOnInvalidFormat(t *testing.T) {
 	}
 	if _, ok := m["err"].(string); !ok {
 		t.Fatalf("err = %v, want string", m["err"])
+	}
+}
+
+func TestSetupRoutesGrpclogThroughSlog(t *testing.T) {
+	old := slog.Default()
+	defer slog.SetDefault(old)
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("LOG_FORMAT", "json")
+	var buf bytes.Buffer
+	setupFromEnv(&buf)
+
+	grpclog.Error("connection reset by peer")
+	grpclog.Warning("transport noise") // maps to debug, gated at info
+
+	recs := jsonLines(t, &buf)
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1 grpc error: %s", len(recs), buf.String())
+	}
+	m := recs[0]
+	if m["level"] != "error" || m["msg"] != "gRPC log" {
+		t.Fatalf("record = %v, want error-level gRPC record", m)
+	}
+	if m["severity"] != "error" {
+		t.Fatalf("severity = %v, want error", m["severity"])
+	}
+	detail, ok := m["detail"].(string)
+	if !ok || !strings.Contains(detail, "connection reset by peer") {
+		t.Fatalf("detail = %v, want the grpclog text", m["detail"])
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -14,6 +14,8 @@ type Scheduler struct {
 	interval          time.Duration
 	podResourceMapper *collector.PodResourceMapper
 	up                prometheus.Gauge
+	// Only touched from the Run goroutine.
+	consecutiveFailures int
 }
 
 func NewScheduler(podResourceMapper *collector.PodResourceMapper, collectors []collector.Collector, interval time.Duration, up prometheus.Gauge) *Scheduler {
@@ -46,12 +48,26 @@ func (s *Scheduler) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			cycleCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			if err := s.RunOnce(cycleCtx); err != nil {
-				slog.Warn("Metrics collection failed", "err", err,
-					"effect", "metrics cleared until next successful collect")
-			}
-			cancel()
+			s.runCycle(ctx)
 		}
+	}
+}
+
+// runCycle wraps RunOnce with failure-streak tracking so the logs mark both
+// edges of an outage: each failed cycle carries its streak position, and the
+// first success afterward records how many cycles were lost.
+func (s *Scheduler) runCycle(ctx context.Context) {
+	cycleCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := s.RunOnce(cycleCtx); err != nil {
+		s.consecutiveFailures++
+		slog.Warn("Metrics collection failed", "err", err,
+			"consecutive_failures", s.consecutiveFailures,
+			"effect", "metrics cleared until next successful collect")
+		return
+	}
+	if s.consecutiveFailures > 0 {
+		slog.Info("Metrics collection recovered", "failed_cycles", s.consecutiveFailures)
+		s.consecutiveFailures = 0
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -48,7 +48,8 @@ func (s *Scheduler) Run(ctx context.Context) {
 		case <-ticker.C:
 			cycleCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			if err := s.RunOnce(cycleCtx); err != nil {
-				slog.Warn("collect metrics failed", slog.Any("err", err))
+				slog.Warn("Metrics collection failed", "err", err,
+					"effect", "metrics cleared until next successful collect")
 			}
 			cancel()
 		}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -62,12 +62,12 @@ func (s *Scheduler) runCycle(ctx context.Context) {
 	if err := s.RunOnce(cycleCtx); err != nil {
 		s.consecutiveFailures++
 		slog.Warn("Metrics collection failed", "err", err,
-			"consecutive_failures", s.consecutiveFailures,
+			"consecutiveFailures", s.consecutiveFailures,
 			"effect", "metrics cleared until next successful collect")
 		return
 	}
 	if s.consecutiveFailures > 0 {
-		slog.Info("Metrics collection recovered", "failed_cycles", s.consecutiveFailures)
+		slog.Info("Metrics collection recovered", "failedCycles", s.consecutiveFailures)
 		s.consecutiveFailures = 0
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,104 @@
+package scheduler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rebellions-sw/rbln-metrics-exporter/internal/collector"
+	"github.com/rebellions-sw/rbln-metrics-exporter/internal/logging"
+)
+
+type fakeCollector struct {
+	errs []error
+}
+
+func (f *fakeCollector) Register(prometheus.Registerer) {}
+
+func (f *fakeCollector) GetMetrics(context.Context) error {
+	if len(f.errs) == 0 {
+		return nil
+	}
+	err := f.errs[0]
+	f.errs = f.errs[1:]
+	return err
+}
+
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	logger, err := logging.New(&buf, "info", "json")
+	if err != nil {
+		t.Fatalf("logging.New: %v", err)
+	}
+	old := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+func jsonRecords(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var recs []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("not JSON: %v: %s", err, line)
+		}
+		recs = append(recs, m)
+	}
+	return recs
+}
+
+func TestRunCycleLogsFailureStreakAndRecovery(t *testing.T) {
+	buf := captureLogs(t)
+	fake := &fakeCollector{errs: []error{errors.New("daemon down"), errors.New("daemon down")}}
+	s := NewScheduler(collector.NewNoopPodResourceMapper(), []collector.Collector{fake}, time.Second, collector.NewUpGauge())
+	ctx := context.Background()
+
+	s.runCycle(ctx) // fail 1
+	s.runCycle(ctx) // fail 2
+	s.runCycle(ctx) // success -> recovery record
+
+	recs := jsonRecords(t, buf)
+	if len(recs) != 3 {
+		t.Fatalf("got %d records, want 3 (2 failures + 1 recovery): %s", len(recs), buf.String())
+	}
+	for i, wantStreak := range []float64{1, 2} {
+		if recs[i]["level"] != "warn" || recs[i]["msg"] != "Metrics collection failed" {
+			t.Fatalf("record %d = %v, want failure warn", i, recs[i])
+		}
+		if recs[i]["consecutive_failures"] != wantStreak {
+			t.Fatalf("record %d consecutive_failures = %v, want %v", i, recs[i]["consecutive_failures"], wantStreak)
+		}
+	}
+	rec := recs[2]
+	if rec["level"] != "info" || rec["msg"] != "Metrics collection recovered" {
+		t.Fatalf("record 2 = %v, want recovery info", rec)
+	}
+	if rec["failed_cycles"] != float64(2) {
+		t.Fatalf("failed_cycles = %v, want 2", rec["failed_cycles"])
+	}
+}
+
+func TestRunCycleStaysQuietOnSteadySuccess(t *testing.T) {
+	buf := captureLogs(t)
+	s := NewScheduler(collector.NewNoopPodResourceMapper(), []collector.Collector{&fakeCollector{}}, time.Second, collector.NewUpGauge())
+	ctx := context.Background()
+
+	s.runCycle(ctx)
+	s.runCycle(ctx)
+
+	if recs := jsonRecords(t, buf); len(recs) != 0 {
+		t.Fatalf("got %d records on steady success, want 0: %s", len(recs), buf.String())
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -77,16 +77,16 @@ func TestRunCycleLogsFailureStreakAndRecovery(t *testing.T) {
 		if recs[i]["level"] != "warn" || recs[i]["msg"] != "Metrics collection failed" {
 			t.Fatalf("record %d = %v, want failure warn", i, recs[i])
 		}
-		if recs[i]["consecutive_failures"] != wantStreak {
-			t.Fatalf("record %d consecutive_failures = %v, want %v", i, recs[i]["consecutive_failures"], wantStreak)
+		if recs[i]["consecutiveFailures"] != wantStreak {
+			t.Fatalf("record %d consecutiveFailures = %v, want %v", i, recs[i]["consecutiveFailures"], wantStreak)
 		}
 	}
 	rec := recs[2]
 	if rec["level"] != "info" || rec["msg"] != "Metrics collection recovered" {
 		t.Fatalf("record 2 = %v, want recovery info", rec)
 	}
-	if rec["failed_cycles"] != float64(2) {
-		t.Fatalf("failed_cycles = %v, want 2", rec["failed_cycles"])
+	if rec["failedCycles"] != float64(2) {
+		t.Fatalf("failedCycles = %v, want 2", rec["failedCycles"])
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -26,6 +27,10 @@ func NewServer(handler http.Handler, port int) *MetricServer {
 		Addr:              fmt.Sprintf(":%d", port),
 		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
+		// Without ErrorLog, net/http's internal records (handler panics,
+		// protocol errors) reach slog through the stdlib-log bridge at info,
+		// invisible to level-based alerting.
+		ErrorLog: slog.NewLogLogger(slog.Default().Handler(), slog.LevelError),
 	}
 
 	return &MetricServer{


### PR DESCRIPTION
  ## Motivation

Exporter logs were plain text at a hardcoded debug level — unusable for log pipelines (Fluent Bit / promtail) and insufficient to debug failures from `kubectl logs` alone. Device-level problems (zeroed telemetry, sick NPUs) were completely invisible in logs, which is exactly the symptom class seen in field issues like the CA25 idle-power case.

  ## Summary of Changes

- Add `internal/logging`: slog-based single-line JSON on stdout, controlled by `LOG_LEVEL` (`error|warning|info|debug|trace`) / `LOG_FORMAT` (`json|text`), defaulting to `info`/`json`. Invalid values fall back per-variable with a warn instead of crash-looping the DaemonSet.
- One log record per failure: errors are wrapped with `%w` on the way up and logged once at the top boundary, with `effect` keys on degradation warnings and camelCase keys throughout.
- Startup snapshot (version + resolved config), collection failure-streak warns, and recovery records; debug/trace diagnostics on collection paths.
- Route gRPC (`grpclog`) and `net/http` internal logs into the structured stream so nothing contaminates the JSON stream with plain-text stderr lines.
- Edge-triggered device visibility records at default level: first collection succeeded (device count), device missing from total info / returned, device entered degraded state / recovered, device no longer serviceable.
- Docs: log stream schema for pipeline operators (README) and commented `LOG_LEVEL`/`LOG_FORMAT` knobs in the reference DaemonSet.