### PR TITLE
refactor(logging): prefix log env vars with RBLN_METRICS_EXPORTER_

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Flags:
 | `RBLN_METRICS_EXPORTER_KUBERNETES_MODE` | `auto` | Kubernetes integration: `auto`, `on`, or `off` |
 | `RBLN_METRICS_EXPORTER_ONESHOT` | `false` | When `true`, scrape once and exit |
 | `NODE_NAME` | auto-detected | Overrides the node label inserted into metrics |
-| `LOG_LEVEL` | `info` | Log level: `error`, `warning`, `info`, `debug`, or `trace` |
-| `LOG_FORMAT` | `json` | Log output format: `json` or `text` |
+| `RBLN_METRICS_EXPORTER_LOG_LEVEL` | `info` | Log level: `error`, `warning`, `info`, `debug`, or `trace` |
+| `RBLN_METRICS_EXPORTER_LOG_FORMAT` | `json` | Log output format: `json` or `text` |
 
-> `LOG_LEVEL=warning` is emitted in logs as `"level":"warn"` (slog's canonical spelling) — write dashboard/alert filters against `warn`, not `warning`.
+> `RBLN_METRICS_EXPORTER_LOG_LEVEL=warning` is emitted in logs as `"level":"warn"` (slog's canonical spelling) — write dashboard/alert filters against `warn`, not `warning`.
 
 > **For log pipelines:** records are single-line JSON (NDJSON) on **stdout**. The timestamp key is `ts` in RFC3339Nano with variable fractional digits — set Fluent Bit's JSON parser to `Time_Key ts`; promtail's `RFC3339Nano` format works as-is. The message key is `msg`, the error key is `err`, and `caller` (`pkg/file.go:N`) appears only at `debug`/`trace`. Keep `json` in-cluster; `text` is meant for local debugging.
 
@@ -301,7 +301,7 @@ rbln_npu_health{card="RBLN-CA25",container="ubuntu",deviceID="1250",driver_versi
 | --- | --- | --- |
 | `rbln_up` is `0` and NPU metrics are absent | Unable to reach RBLN daemon | Verify `RBLN_METRICS_EXPORTER_RBLN_DAEMON_URL`, ensure daemon is listening, check firewall |
 | No Kubernetes labels | Pod-resources socket missing | Confirm `/var/lib/kubelet/pod-resources/kubelet.sock` is mounted and kubelet exposes the API |
-| No Kubernetes labels, DRA-allocated devices only | Kubelet is not reporting DRA allocations | Confirm the cluster is Kubernetes `>= 1.34` (see [Dynamic Resource Allocation](#dynamic-resource-allocation-dra)); run the exporter with `LOG_LEVEL=debug` and check the `Synced pod resources` record's device count |
+| No Kubernetes labels, DRA-allocated devices only | Kubelet is not reporting DRA allocations | Confirm the cluster is Kubernetes `>= 1.34` (see [Dynamic Resource Allocation](#dynamic-resource-allocation-dra)); run the exporter with `RBLN_METRICS_EXPORTER_LOG_LEVEL=debug` and check the `Synced pod resources` record's device count |
 | Pod labels name only one of several pods sharing a device | Those pods reference one `ResourceClaim` | Expected — a series holds one set of labels. `rbln_npu_device_shared` is `1` for those devices; see [Dynamic Resource Allocation](#dynamic-resource-allocation-dra) |
 | Scrape errors in Prometheus | Authorization/namespace mismatch | Ensure Service or ServiceMonitor selects the exporter pods and Prometheus is allowed to scrape the namespace |
 | Gateway returns HTTP 400 | Missing `?target=` parameter | Check the `relabel_configs` copy rules run before `__address__` is replaced |

--- a/deployments/kubernetes/daemonset.yaml
+++ b/deployments/kubernetes/daemonset.yaml
@@ -47,9 +47,9 @@ spec:
             - name: RBLN_METRICS_EXPORTER_RBLN_DAEMON_URL
               value: "$(NODE_IP):50051"
             # Uncomment to override the logging defaults (info level, json format)
-            # - name: LOG_LEVEL
+            # - name: RBLN_METRICS_EXPORTER_LOG_LEVEL
             #   value: "debug"
-            # - name: LOG_FORMAT
+            # - name: RBLN_METRICS_EXPORTER_LOG_FORMAT
             #   value: "json"
           volumeMounts:
             - name: pod-resources

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,6 +1,6 @@
 // Package logging configures the process-wide slog logger: structured json
-// or text records controlled by LOG_LEVEL and LOG_FORMAT, defaulting to
-// info/json.
+// or text records controlled by RBLN_METRICS_EXPORTER_LOG_LEVEL and
+// RBLN_METRICS_EXPORTER_LOG_FORMAT, defaulting to info/json.
 package logging
 
 import (
@@ -10,6 +10,13 @@ import (
 	"os"
 	"strings"
 	"time"
+)
+
+// Env vars follow the project-wide RBLN_METRICS_EXPORTER_* prefix so
+// generic names cannot be captured by unrelated env injection.
+const (
+	envLogLevel  = "RBLN_METRICS_EXPORTER_LOG_LEVEL"
+	envLogFormat = "RBLN_METRICS_EXPORTER_LOG_FORMAT"
 )
 
 // LevelTrace extends slog's levels downward with a "trace" level below debug.
@@ -43,7 +50,8 @@ func New(w io.Writer, level, format string) (*slog.Logger, error) {
 	return slog.New(h), nil
 }
 
-// SetupFromEnv reads LOG_LEVEL / LOG_FORMAT and installs the logger.
+// SetupFromEnv reads RBLN_METRICS_EXPORTER_LOG_LEVEL / _LOG_FORMAT and
+// installs the logger.
 // Empty values mean info/json (production defaults). Invalid values do not
 // kill the process — a typo in a DaemonSet env would CrashLoopBackOff the
 // exporter and drop all telemetry from the node. Instead, only the offending
@@ -53,7 +61,7 @@ func SetupFromEnv() {
 }
 
 func setupFromEnv(w io.Writer) {
-	level, format := os.Getenv("LOG_LEVEL"), os.Getenv("LOG_FORMAT")
+	level, format := os.Getenv(envLogLevel), os.Getenv(envLogFormat)
 	var levelErr, formatErr error
 	if _, err := parseLevel(level); err != nil {
 		levelErr, level = err, "info"
@@ -69,14 +77,14 @@ func setupFromEnv(w io.Writer) {
 	}
 	slog.SetDefault(logger)
 	redirectGrpclog()
-	// With LOG_LEVEL=error and an invalid LOG_FORMAT, the format Warn is
-	// suppressed by the level gate — accepted, since the error gate was
-	// explicitly requested.
+	// With the level env set to error and an invalid format env, the format
+	// Warn is suppressed by the level gate — accepted, since the error gate
+	// was explicitly requested.
 	if levelErr != nil {
-		slog.Warn("Invalid LOG_LEVEL, using default", "err", levelErr, "fallback", "info")
+		slog.Warn("Invalid "+envLogLevel+", using default", "err", levelErr, "fallback", "info")
 	}
 	if formatErr != nil {
-		slog.Warn("Invalid LOG_FORMAT, using default", "err", formatErr, "fallback", "json")
+		slog.Warn("Invalid "+envLogFormat+", using default", "err", formatErr, "fallback", "json")
 	}
 }
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -185,8 +185,8 @@ func jsonLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
 func TestSetupFromEnvFallsBack(t *testing.T) {
 	old := slog.Default()
 	defer slog.SetDefault(old)
-	t.Setenv("LOG_LEVEL", "bogus")
-	t.Setenv("LOG_FORMAT", "json")
+	t.Setenv(envLogLevel, "bogus")
+	t.Setenv(envLogFormat, "json")
 	var buf bytes.Buffer
 	setupFromEnv(&buf)
 	ctx := context.Background()
@@ -201,8 +201,8 @@ func TestSetupFromEnvFallsBack(t *testing.T) {
 func TestSetupFromEnvWarnsFallbackRecordOnInvalidLevel(t *testing.T) {
 	old := slog.Default()
 	defer slog.SetDefault(old)
-	t.Setenv("LOG_LEVEL", "bogus")
-	t.Setenv("LOG_FORMAT", "json")
+	t.Setenv(envLogLevel, "bogus")
+	t.Setenv(envLogFormat, "json")
 	var buf bytes.Buffer
 	setupFromEnv(&buf)
 	recs := jsonLines(t, &buf)
@@ -210,8 +210,8 @@ func TestSetupFromEnvWarnsFallbackRecordOnInvalidLevel(t *testing.T) {
 		t.Fatalf("got %d records, want 1 fallback warn: %s", len(recs), buf.String())
 	}
 	m := recs[0]
-	if m["level"] != "warn" || m["msg"] != "Invalid LOG_LEVEL, using default" {
-		t.Fatalf("record = %v, want LOG_LEVEL fallback warn", m)
+	if m["level"] != "warn" || m["msg"] != "Invalid "+envLogLevel+", using default" {
+		t.Fatalf("record = %v, want %s fallback warn", m, envLogLevel)
 	}
 	if m["fallback"] != "info" {
 		t.Fatalf("fallback = %v, want info", m["fallback"])
@@ -225,8 +225,8 @@ func TestSetupFromEnvWarnsFallbackRecordOnInvalidLevel(t *testing.T) {
 func TestSetupFromEnvWarnsFallbackRecordOnInvalidFormat(t *testing.T) {
 	old := slog.Default()
 	defer slog.SetDefault(old)
-	t.Setenv("LOG_LEVEL", "info")
-	t.Setenv("LOG_FORMAT", "xml")
+	t.Setenv(envLogLevel, "info")
+	t.Setenv(envLogFormat, "xml")
 	var buf bytes.Buffer
 	setupFromEnv(&buf)
 	recs := jsonLines(t, &buf)
@@ -234,8 +234,8 @@ func TestSetupFromEnvWarnsFallbackRecordOnInvalidFormat(t *testing.T) {
 		t.Fatalf("got %d records, want 1 fallback warn: %s", len(recs), buf.String())
 	}
 	m := recs[0]
-	if m["level"] != "warn" || m["msg"] != "Invalid LOG_FORMAT, using default" {
-		t.Fatalf("record = %v, want LOG_FORMAT fallback warn", m)
+	if m["level"] != "warn" || m["msg"] != "Invalid "+envLogFormat+", using default" {
+		t.Fatalf("record = %v, want %s fallback warn", m, envLogFormat)
 	}
 	if m["fallback"] != "json" {
 		t.Fatalf("fallback = %v, want json", m["fallback"])
@@ -248,8 +248,8 @@ func TestSetupFromEnvWarnsFallbackRecordOnInvalidFormat(t *testing.T) {
 func TestSetupRoutesGrpclogThroughSlog(t *testing.T) {
 	old := slog.Default()
 	defer slog.SetDefault(old)
-	t.Setenv("LOG_LEVEL", "info")
-	t.Setenv("LOG_FORMAT", "json")
+	t.Setenv(envLogLevel, "info")
+	t.Setenv(envLogFormat, "json")
 	var buf bytes.Buffer
 	setupFromEnv(&buf)
 


### PR DESCRIPTION
## Motivation
`internal/logging` read the unprefixed `LOG_LEVEL` / `LOG_FORMAT`, while every other env var in this repo uses the `RBLN_METRICS_EXPORTER_` prefix (e.g. `RBLN_METRICS_EXPORTER_RBLN_DAEMON_URL`). Logging was the only exception, which is inconsistent within the repo, and generic names can be captured by unrelated env injection. This aligns the exporter with the other Rebellions repos, which already prefix their logging env vars for the same reason.

  ## Summary of Changes
- Rename `LOG_LEVEL` / `LOG_FORMAT` to `RBLN_METRICS_EXPORTER_LOG_LEVEL` / `RBLN_METRICS_EXPORTER_LOG_FORMAT`.
- Update the commented-out env examples in the reference DaemonSet manifest.